### PR TITLE
Improve conversion to PETSc

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,7 +23,7 @@ jobs:
           - { isMerge: false, python-version: 3.9 }
           - { isMerge: false, python-version: '3.10' }
         include:
-          - os: macos-latest
+          - os: macos-12
             python-version: '3.10'
 
     name: ${{ matrix.os }} / Python ${{ matrix.python-version }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,7 +23,7 @@ jobs:
           - { isMerge: false, python-version: 3.9 }
           - { isMerge: false, python-version: '3.10' }
         include:
-          - os: macos-12
+          - os: macos-latest
             python-version: '3.10'
 
     name: ${{ matrix.os }} / Python ${{ matrix.python-version }}

--- a/psydac/linalg/kernels/stencil2IJV_kernels.py
+++ b/psydac/linalg/kernels/stencil2IJV_kernels.py
@@ -1,0 +1,215 @@
+# coding: utf-8
+from pyccel.decorators import template
+
+
+#========================================================================================================
+@template(name='T', types=[float, complex])
+def stencil2IJV_1d_C(A:'T[:,:]', Ib:'int64[:]', Jb:'int64[:]', Vb:'T[:]', rowmapb:'int64[:]',
+                     cnl1:'int64', dng1:'int64', cs1:'int64', cp1:'int64', cm1:'int64',
+                     dsh:'int64[:]', csh:'int64[:]', dgs1:'int64[:]', dge1:'int64[:]', 
+                     cgs1:'int64[:]', cge1:'int64[:]', dnlb1:'int64[:]', cnlb1:'int64[:]'):
+
+    nnz = 0
+    nnz_rows = 0
+    gr1 = cp1*cm1
+
+    for i1 in range(cnl1):
+        nnz_in_row = 0
+        i1_n = cs1 + i1
+
+        pr_i1 = 0
+        for k in range(cgs1.size):
+            if i1_n < cgs1[k] or i1_n > cge1[k]:continue
+            pr_i1 = k
+
+        i_g = csh[pr_i1] + i1_n - cgs1[pr_i1]
+
+        stencil_size1 = A[i1 + gr1].size
+
+        for k1 in range(stencil_size1):
+
+            j1_n = (i1_n + k1 - stencil_size1//2) % dng1 
+            value = A[i1 + gr1, k1]
+
+            if abs(value) == 0.0:continue
+            
+            pr_j1 = 0
+            for k in range(dgs1.size):
+                if j1_n < dgs1[k] or j1_n > dge1[k]:continue
+                pr_j1 = k            
+                         
+            j_g = dsh[pr_j1] + j1_n - dgs1[pr_j1]
+
+            if nnz_in_row == 0:
+                rowmapb[nnz_rows] = i_g  
+
+            Jb[nnz] = j_g           
+            Vb[nnz] = value  
+            nnz += 1
+
+            nnz_in_row += 1
+
+        if nnz_in_row > 0:
+            Ib[1 + nnz_rows] = Ib[nnz_rows] + nnz_in_row
+            nnz_rows += 1
+
+    return nnz_rows, nnz
+
+#========================================================================================================
+@template(name='T', types=[float, complex])
+def stencil2IJV_2d_C(A:'T[:,:,:,:]', Ib:'int64[:]', Jb:'int64[:]', Vb:'T[:]', rowmapb:'int64[:]',
+                     cnl1:'int64', cnl2:'int64', dng1:'int64', dng2:'int64', cs1:'int64', 
+                     cs2:'int64', cp1:'int64', cp2:'int64', cm1:'int64', cm2:'int64',
+                     dsh:'int64[:]', csh:'int64[:]', dgs1:'int64[:]', dgs2:'int64[:]', 
+                     dge1:'int64[:]', dge2:'int64[:]', cgs1:'int64[:]', cgs2:'int64[:]', 
+                     cge1:'int64[:]', cge2:'int64[:]', dnlb1:'int64[:]', dnlb2:'int64[:]', 
+                     cnlb1:'int64[:]', cnlb2:'int64[:]'):
+
+    nnz = 0
+    nnz_rows = 0
+    gr1 = cp1*cm1
+    gr2 = cp2*cm2
+
+    for i1 in range(cnl1):
+        for i2 in range(cnl2):
+            nnz_in_row = 0
+            i1_n = cs1 + i1
+            i2_n = cs2 + i2
+
+            pr_i1 = 0
+            for k in range(cgs1.size):
+                if i1_n < cgs1[k] or i1_n > cge1[k]:continue
+                pr_i1 = k
+            pr_i2 = 0
+            for k in range(cgs2.size):
+                if i2_n < cgs2[k] or i2_n > cge2[k]:continue
+                pr_i2 = k
+
+            pr_i = pr_i2 + pr_i1 * cgs2.size
+
+            i_g = csh[pr_i] + i2_n - cgs2[pr_i2] + (i1_n - cgs1[pr_i1]) * cnlb2[pr_i]
+
+            stencil_size1, stencil_size2 = A.shape[2:]
+
+            for k1 in range(stencil_size1):
+                for k2 in range(stencil_size2):
+                    j1_n = (i1_n + k1 - stencil_size1//2) % dng1 
+                    j2_n = (i2_n + k2 - stencil_size2//2) % dng2
+
+                    value = A[i1 + gr1, i2 + gr2, k1, k2]
+                    if abs(value) == 0.0:continue
+                    
+                    pr_j1 = 0
+                    for k in range(dgs1.size):
+                        if j1_n < dgs1[k] or j1_n > dge1[k]:continue
+                        pr_j1 = k
+                    pr_j2 = 0
+                    for k in range(dgs2.size):
+                        if j2_n < dgs2[k] or j2_n > dge2[k]:continue
+                        pr_j2 = k
+
+                    pr_j = pr_j2 + pr_j1 * dgs2.size
+                                
+                    j_g = dsh[pr_j] + j2_n - dgs2[pr_j2] + (j1_n - dgs1[pr_j1]) * dnlb2[pr_j]
+
+                    if nnz_in_row == 0:
+                        rowmapb[nnz_rows] = i_g  
+
+                    Jb[nnz] = j_g           
+                    Vb[nnz] = value  
+                    nnz += 1
+
+                    nnz_in_row += 1
+
+            if nnz_in_row > 0:
+                Ib[1 + nnz_rows] = Ib[nnz_rows] + nnz_in_row
+                nnz_rows += 1
+
+    return nnz_rows, nnz
+
+
+#========================================================================================================
+@template(name='T', types=[float, complex])
+def stencil2IJV_3d_C(A:'T[:,:,:,:,:,:]', Ib:'int64[:]', Jb:'int64[:]', Vb:'T[:]', rowmapb:'int64[:]',
+                     cnl1:'int64', cnl2:'int64', cnl3:'int64', dng1:'int64', dng2:'int64', dng3:'int64', 
+                     cs1:'int64', cs2:'int64', cs3:'int64', cp1:'int64', cp2:'int64', cp3:'int64', 
+                     cm1:'int64', cm2:'int64', cm3:'int64', dsh:'int64[:]', csh:'int64[:]',
+                     dgs1:'int64[:]', dgs2:'int64[:]', dgs3:'int64[:]', dge1:'int64[:]', dge2:'int64[:]', 
+                     dge3:'int64[:]', cgs1:'int64[:]', cgs2:'int64[:]', cgs3:'int64[:]', 
+                     cge1:'int64[:]', cge2:'int64[:]', cge3:'int64[:]', dnlb1:'int64[:]', dnlb2:'int64[:]', 
+                     dnlb3:'int64[:]', cnlb1:'int64[:]', cnlb2:'int64[:]', cnlb3:'int64[:]'):
+
+    nnz = 0
+    nnz_rows = 0
+    gr1 = cp1*cm1
+    gr2 = cp2*cm2
+    gr3 = cp3*cm3
+
+    for i1 in range(cnl1):
+        for i2 in range(cnl2):
+            for i3 in range(cnl3):
+                nnz_in_row = 0
+                i1_n = cs1 + i1
+                i2_n = cs2 + i2
+                i3_n = cs3 + i3
+
+                pr_i1 = 0
+                for k in range(cgs1.size):
+                    if i1_n < cgs1[k] or i1_n > cge1[k]:continue
+                    pr_i1 = k
+                pr_i2 = 0
+                for k in range(cgs2.size):
+                    if i2_n < cgs2[k] or i2_n > cge2[k]:continue
+                    pr_i2 = k
+                pr_i3 = 0
+                for k in range(cgs3.size):
+                    if i3_n < cgs3[k] or i3_n > cge3[k]:continue
+                    pr_i3 = k                    
+
+                pr_i = pr_i3 + pr_i2 * cgs3.size + pr_i1 * cgs2.size * cgs3.size
+
+                i_g = csh[pr_i] + i3_n - cgs3[pr_i3] + (i2_n - cgs2[pr_i2]) * cnlb3[pr_i] + (i1_n - cgs1[pr_i1]) * cnlb2[pr_i] * cnlb3[pr_i]
+
+                stencil_size1, stencil_size2, stencil_size3 = A.shape[3:]
+
+                for k1 in range(stencil_size1):
+                    for k2 in range(stencil_size2):
+                        for k3 in range(stencil_size3):
+                            j1_n = (i1_n + k1 - stencil_size1//2) % dng1 
+                            j2_n = (i2_n + k2 - stencil_size2//2) % dng2
+                            j3_n = (i3_n + k3 - stencil_size3//2) % dng3
+
+                            value = A[i1 + gr1, i2 + gr2, i3 + gr3, k1, k2, k3]
+                            if abs(value) == 0.0:continue
+                            
+                            pr_j1 = 0
+                            for k in range(dgs1.size):
+                                if j1_n < dgs1[k] or j1_n > dge1[k]:continue
+                                pr_j1 = k
+                            pr_j2 = 0
+                            for k in range(dgs2.size):
+                                if j2_n < dgs2[k] or j2_n > dge2[k]:continue
+                                pr_j2 = k
+                            pr_j3 = 0
+                            for k in range(dgs3.size):
+                                if j3_n < dgs3[k] or j3_n > dge3[k]:continue
+                                pr_j3 = k  
+
+                            pr_j = pr_j3 + pr_j2 * dgs3.size + pr_j1 * dgs2.size * dgs3.size
+
+                            j_g = dsh[pr_j] + j3_n - dgs3[pr_j3] + (j2_n - dgs2[pr_j2]) * dnlb3[pr_j] + (j1_n - dgs1[pr_j1]) * dnlb2[pr_j] * dnlb3[pr_j]
+
+                            if nnz_in_row == 0:
+                                rowmapb[nnz_rows] = i_g  
+
+                            Jb[nnz] = j_g           
+                            Vb[nnz] = value  
+                            nnz += 1
+
+                            nnz_in_row += 1
+
+                if nnz_in_row > 0:
+                    Ib[1 + nnz_rows] = Ib[nnz_rows] + nnz_in_row
+                    nnz_rows += 1
+
+    return nnz_rows, nnz

--- a/psydac/linalg/tests/test_stencil_matrix.py
+++ b/psydac/linalg/tests/test_stencil_matrix.py
@@ -2854,7 +2854,7 @@ def test_stencil_matrix_1d_parallel_topetsc(dtype, n1, p1, sh1, P1):
     y_p = petsc_to_psydac(y_petsc, V)
 
     assert np.allclose(y_p.toarray(), y.toarray(), rtol=1e-12, atol=1e-12)
-#test_stencil_matrix_1d_parallel_topetsc(float, 5, 2, 1, True)
+
 # ===============================================================================
 
 @pytest.mark.parametrize('n1', [4,7])
@@ -2909,8 +2909,6 @@ def test_mass_matrix_2d_parallel_topetsc(n1, n2, p1, p2, P1, P2):
     y_p = petsc_to_psydac(y_petsc, Vh.vector_space)
 
     assert np.allclose(y_p.toarray(), y.toarray(), rtol=1e-12, atol=1e-12)
-    
-#test_mass_matrix_2d_parallel_topetsc(10, 13, 3, 2, True, True)
 
 # ===============================================================================
 
@@ -2971,8 +2969,6 @@ def test_mass_matrix_3d_parallel_topetsc(n1, n2, n3, p1, p2, p3, P1, P2, P3):
 
     assert np.allclose(y_p.toarray(), y.toarray(), rtol=1e-12, atol=1e-12)
     
-#test_mass_matrix_3d_parallel_topetsc(7, 3, 5, 1, 1, 2, True, True, True)
-
 # ===============================================================================    
 
 @pytest.mark.parametrize('n1', [15,17])
@@ -3016,10 +3012,8 @@ def test_mass_matrix_1d_parallel_topetsc(n1, p1, P1):
     # Convert stencil matrix to PETSc.Mat
     Mp = M.topetsc()
 
-    #print('\nMp.getSizes()=', Mp.getSizes())
     # Create Vec to allocate the result of the dot product
     y_petsc = Mp.createVecLeft()
-    #print('y_petsc.getSizes()=', y_petsc.getSizes())
 
     x_petsc = x.topetsc()
     # Compute dot product
@@ -3027,25 +3021,8 @@ def test_mass_matrix_1d_parallel_topetsc(n1, p1, P1):
     # Cast result back to Psydac StencilVector format
     y_p = petsc_to_psydac(y_petsc, Vh.vector_space)
 
-    ################################################
-    # Note 12.03.2024:
-    # Another possibility would be to compare y_petsc.array and y.toarray(). 
-    # However, we cannot do this because PETSc distributes matrices and vectors different than Psydac.
-    # In the future we would like that PETSc uses the partition from Psydac, 
-    # which might involve passing a DM Object.
-    ################################################
-    '''for k in range(comm.Get_size()):
-        if comm.Get_rank() == k:
-            print('\n\nRank ', k)
-            print('x=\n', x.toarray())
-            print('x_petsc=\n', x_petsc.array)
-
-            print('MAX_DIFF=', abs((y-y_p).toarray()).max())
-        comm.Barrier()'''
-
     assert np.allclose(y_p.toarray(), y.toarray(), rtol=1e-12, atol=1e-12)
 
-#test_mass_matrix_1d_parallel_topetsc(2, 1, False)
 # ===============================================================================
 # PARALLEL BACKENDS TESTS
 # ===============================================================================

--- a/psydac/linalg/tests/test_stencil_matrix.py
+++ b/psydac/linalg/tests/test_stencil_matrix.py
@@ -2779,19 +2779,12 @@ def test_stencil_matrix_2d_parallel_topetsc(dtype, n1, n2, p1, p2, sh1, sh2, P1,
     # Cast result back to Psydac StencilVector format
     y_p = petsc_to_psydac(y_petsc, V)
 
-    ################################################
-    # Note 12.03.2024:
-    # Another possibility would be to compare y_petsc.array and y.toarray(). 
-    # However, we cannot do this because PETSc distributes matrices and vectors different than Psydac.
-    # In the future we would like that PETSc uses the partition from Psydac, 
-    # which might involve passing a DM Object.
-    ################################################
     assert np.allclose(y_p.toarray(), y.toarray(), rtol=1e-12, atol=1e-12)
 
 # ===============================================================================
 
 @pytest.mark.parametrize('dtype', [float, complex])
-@pytest.mark.parametrize('n1', [7, 11])
+@pytest.mark.parametrize('n1', [13, 15])
 @pytest.mark.parametrize('p1', [1, 3])
 @pytest.mark.parametrize('sh1', [1])
 @pytest.mark.parametrize('P1', [True, False])
@@ -2860,13 +2853,6 @@ def test_stencil_matrix_1d_parallel_topetsc(dtype, n1, p1, sh1, P1):
     # Cast result back to Psydac StencilVector format
     y_p = petsc_to_psydac(y_petsc, V)
 
-    ################################################
-    # Note 12.03.2024:
-    # Another possibility would be to compare y_petsc.array and y.toarray(). 
-    # However, we cannot do this because PETSc distributes matrices and vectors different than Psydac.
-    # In the future we would like that PETSc uses the partition from Psydac, 
-    # which might involve passing a DM Object.
-    ################################################
     assert np.allclose(y_p.toarray(), y.toarray(), rtol=1e-12, atol=1e-12)
 #test_stencil_matrix_1d_parallel_topetsc(float, 5, 2, 1, True)
 # ===============================================================================
@@ -2922,22 +2908,9 @@ def test_mass_matrix_2d_parallel_topetsc(n1, n2, p1, p2, P1, P2):
     # Cast result back to Psydac StencilVector format
     y_p = petsc_to_psydac(y_petsc, Vh.vector_space)
 
-    ################################################
-    # Note 12.03.2024:
-    # Another possibility would be to compare y_petsc.array and y.toarray(). 
-    # However, we cannot do this because PETSc distributes matrices and vectors different than Psydac.
-    # In the future we would like that PETSc uses the partition from Psydac, 
-    # which might involve passing a DM Object.
-    ################################################
-    for k in range(comm.Get_size()):
-        if k == comm.Get_rank():
-            print('rank ', comm.Get_rank(), ':y_p.toarray()=\n', y_p.toarray())
-            print('rank ', comm.Get_rank(), ': y.toarray()=\n', y.toarray())
-        comm.Barrier()
-
     assert np.allclose(y_p.toarray(), y.toarray(), rtol=1e-12, atol=1e-12)
     
-test_mass_matrix_2d_parallel_topetsc(2, 3, 1, 1, True, False)
+#test_mass_matrix_2d_parallel_topetsc(10, 13, 3, 2, True, True)
 
 # ===============================================================================
 
@@ -3002,7 +2975,7 @@ def test_mass_matrix_3d_parallel_topetsc(n1, n2, n3, p1, p2, p3, P1, P2, P3):
 
 # ===============================================================================    
 
-@pytest.mark.parametrize('n1', [4,7])
+@pytest.mark.parametrize('n1', [15,17])
 @pytest.mark.parametrize('p1', [2])
 @pytest.mark.parametrize('P1', [True])
 @pytest.mark.parallel
@@ -3072,7 +3045,7 @@ def test_mass_matrix_1d_parallel_topetsc(n1, p1, P1):
 
     assert np.allclose(y_p.toarray(), y.toarray(), rtol=1e-12, atol=1e-12)
 
-#test_mass_matrix_1d_parallel_topetsc(12, 3, True)
+#test_mass_matrix_1d_parallel_topetsc(2, 1, False)
 # ===============================================================================
 # PARALLEL BACKENDS TESTS
 # ===============================================================================

--- a/psydac/linalg/tests/test_stencil_matrix.py
+++ b/psydac/linalg/tests/test_stencil_matrix.py
@@ -24,9 +24,6 @@ def compute_global_starts_ends(domain_decomposition, npts, pads):
     global_starts = [None] * ndims
     global_ends = [None] * ndims
 
-    print('\ndomain_decomposition.global_element_starts', domain_decomposition.global_element_starts)
-    print('domain_decomposition.global_element_ends', domain_decomposition.global_element_ends)
-
     for axis in range(ndims):
         ee = domain_decomposition.global_element_ends[axis]
         

--- a/psydac/linalg/tests/test_stencil_matrix.py
+++ b/psydac/linalg/tests/test_stencil_matrix.py
@@ -2773,7 +2773,7 @@ def test_stencil_matrix_2d_parallel_topetsc(dtype, n1, n2, p1, p2, sh1, sh2, P1,
     # Convert stencil matrix to PETSc.Mat
     Mp = M.topetsc()
     # Create Vec to allocate the result of the dot product
-    y_petsc = Mp.createVecRight()
+    y_petsc = Mp.createVecLeft()
     # Compute dot product
     Mp.mult(x.topetsc(), y_petsc)
     # Cast result back to Psydac StencilVector format
@@ -2789,13 +2789,94 @@ def test_stencil_matrix_2d_parallel_topetsc(dtype, n1, n2, p1, p2, sh1, sh2, P1,
     assert np.allclose(y_p.toarray(), y.toarray(), rtol=1e-12, atol=1e-12)
 
 # ===============================================================================
+
+@pytest.mark.parametrize('dtype', [float, complex])
+@pytest.mark.parametrize('n1', [7, 11])
+@pytest.mark.parametrize('p1', [1, 3])
+@pytest.mark.parametrize('sh1', [1])
+@pytest.mark.parametrize('P1', [True, False])
+@pytest.mark.parallel
+@pytest.mark.petsc
+
+def test_stencil_matrix_1d_parallel_topetsc(dtype, n1, p1, sh1, P1):
+    from mpi4py import MPI
+
+    # Select non-zero values based on diagonal index
+    nonzero_values = dict()
+    if dtype==complex:
+        for k1 in range(-p1, p1 + 1):
+                nonzero_values[k1] = 10j * k1 + 7
+    else:
+        for k1 in range(-p1, p1 + 1):
+                nonzero_values[k1] = 10 * k1 + 7
+
+    # Create domain decomposition: decomposes the coefficients
+    comm = MPI.COMM_WORLD
+    D = DomainDecomposition([n1], periods=[P1], comm=comm)
+
+    # Partition the coefficients
+    npts = [n1] #Number of cells
+    global_starts, global_ends = compute_global_starts_ends(D, npts, [p1])
+
+    # In cart, npts must be the number of coefficients.
+    cart = CartDecomposition(D, npts, global_starts, global_ends, pads=[p1], shifts=[sh1])
+
+    # Create vector space and stencil matrix
+    V = StencilVectorSpace(cart, dtype=dtype)
+    M = StencilMatrix(V, V)
+    x = StencilVector(V)
+
+    s1, = V.starts
+    e1, = V.ends    
+
+    # Fill in stencil matrix values
+    for i1 in range(s1, e1 + 1):
+        for k1 in range(-p1, p1 + 1):
+                M[i1, k1] = (i1+1)*nonzero_values[k1]
+
+    # Fill in vector with random values, then update ghost regions
+    if dtype == complex:
+        for i1 in range(s1, e1 + 1):
+            x[i1] = 2.0j * random() - 1.0
+    else:
+        for i1 in range(s1, e1 + 1):
+            x[i1] = 2.0 * random() - 1.0
+    x.update_ghost_regions()
+
+    # If any dimension is not periodic, set corresponding periodic corners to zero
+    M.remove_spurious_entries()
+
+    # Convert stencil matrix to PETSc.Mat
+    Mp = M.topetsc()
+
+    y = M.dot(x)
     
+    # Convert stencil matrix to PETSc.Mat
+    Mp = M.topetsc()
+    # Create Vec to allocate the result of the dot product
+    y_petsc = Mp.createVecLeft()
+    # Compute dot product
+    Mp.mult(x.topetsc(), y_petsc)
+    # Cast result back to Psydac StencilVector format
+    y_p = petsc_to_psydac(y_petsc, V)
+
+    ################################################
+    # Note 12.03.2024:
+    # Another possibility would be to compare y_petsc.array and y.toarray(). 
+    # However, we cannot do this because PETSc distributes matrices and vectors different than Psydac.
+    # In the future we would like that PETSc uses the partition from Psydac, 
+    # which might involve passing a DM Object.
+    ################################################
+    assert np.allclose(y_p.toarray(), y.toarray(), rtol=1e-12, atol=1e-12)
+#test_stencil_matrix_1d_parallel_topetsc(float, 5, 2, 1, True)
+# ===============================================================================
+
 @pytest.mark.parametrize('n1', [4,7])
 @pytest.mark.parametrize('n2', [3,5])
 @pytest.mark.parametrize('p1', [2])
 @pytest.mark.parametrize('p2', [1])
-@pytest.mark.parametrize('P1', [True])
-@pytest.mark.parametrize('P2', [True])
+@pytest.mark.parametrize('P1', [True, False])
+@pytest.mark.parametrize('P2', [True, False])
 @pytest.mark.parallel
 @pytest.mark.petsc
 
@@ -2835,7 +2916,7 @@ def test_mass_matrix_2d_parallel_topetsc(n1, n2, p1, p2, P1, P2):
     # Convert stencil matrix to PETSc.Mat
     Mp = M.topetsc()
     # Create Vec to allocate the result of the dot product
-    y_petsc = Mp.createVecRight()
+    y_petsc = Mp.createVecLeft()
     # Compute dot product
     Mp.mult(x.topetsc(), y_petsc)
     # Cast result back to Psydac StencilVector format
@@ -2848,9 +2929,150 @@ def test_mass_matrix_2d_parallel_topetsc(n1, n2, p1, p2, P1, P2):
     # In the future we would like that PETSc uses the partition from Psydac, 
     # which might involve passing a DM Object.
     ################################################
+    for k in range(comm.Get_size()):
+        if k == comm.Get_rank():
+            print('rank ', comm.Get_rank(), ':y_p.toarray()=\n', y_p.toarray())
+            print('rank ', comm.Get_rank(), ': y.toarray()=\n', y.toarray())
+        comm.Barrier()
+
+    assert np.allclose(y_p.toarray(), y.toarray(), rtol=1e-12, atol=1e-12)
+    
+test_mass_matrix_2d_parallel_topetsc(2, 3, 1, 1, True, False)
+
+# ===============================================================================
+
+@pytest.mark.parametrize('n1', [4,7])
+@pytest.mark.parametrize('n2', [3,5])
+@pytest.mark.parametrize('n3', [3,4])
+@pytest.mark.parametrize('p1', [2])
+@pytest.mark.parametrize('p2', [1])
+@pytest.mark.parametrize('p3', [1])
+@pytest.mark.parametrize('P1', [False])
+@pytest.mark.parametrize('P2', [True])
+@pytest.mark.parametrize('P3', [True, False])
+@pytest.mark.parallel
+@pytest.mark.petsc
+
+def test_mass_matrix_3d_parallel_topetsc(n1, n2, n3, p1, p2, p3, P1, P2, P3):
+    from sympde.topology import Cube, ScalarFunctionSpace, element_of
+    from sympde.expr     import BilinearForm, integral
+    from psydac.api.settings            import PSYDAC_BACKENDS
+    from psydac.api.discretization      import discretize
+    from mpi4py import MPI
+
+    domain = Cube()
+    V = ScalarFunctionSpace('V', domain)
+
+    u = element_of(V, name='u')
+    v = element_of(V, name='v')    
+
+    a = BilinearForm((u, v), integral(domain, u * v))
+    comm = MPI.COMM_WORLD
+    domain_h = discretize(domain, ncells=[n1,n2,n3], periodic=[P1,P2,P3], comm=comm)
+    Vh = discretize(V, domain_h, degree=[p1,p2,p3])
+    ah = discretize(a, domain_h, [Vh, Vh], backend=PSYDAC_BACKENDS['pyccel-gcc'])    
+    M = ah.assemble()
+
+    x = Vh.vector_space.zeros()
+
+    s1, s2, s3 = Vh.vector_space.starts
+    e1, e2, e3 = Vh.vector_space.ends
+
+    # Fill in vector with random values, then update ghost regions
+    for i1 in range(s1, e1 + 1):
+        for i2 in range(s2, e2 + 1):
+            for i3 in range(s3, e3 + 1):
+                x[i1, i2, i3] = 2.0 * random() - 1.0
+    x.update_ghost_regions()
+
+    y = M.dot(x)
+    
+    # Convert stencil matrix to PETSc.Mat
+    Mp = M.topetsc()
+    # Create Vec to allocate the result of the dot product
+    y_petsc = Mp.createVecLeft()
+    # Compute dot product
+    Mp.mult(x.topetsc(), y_petsc)
+    # Cast result back to Psydac StencilVector format
+    y_p = petsc_to_psydac(y_petsc, Vh.vector_space)
+
+    assert np.allclose(y_p.toarray(), y.toarray(), rtol=1e-12, atol=1e-12)
+    
+#test_mass_matrix_3d_parallel_topetsc(7, 3, 5, 1, 1, 2, True, True, True)
+
+# ===============================================================================    
+
+@pytest.mark.parametrize('n1', [4,7])
+@pytest.mark.parametrize('p1', [2])
+@pytest.mark.parametrize('P1', [True])
+@pytest.mark.parallel
+@pytest.mark.petsc
+
+def test_mass_matrix_1d_parallel_topetsc(n1, p1, P1):
+    from sympde.topology import Line, ScalarFunctionSpace, element_of
+    from sympde.expr     import BilinearForm, integral
+    from psydac.api.settings            import PSYDAC_BACKENDS
+    from psydac.api.discretization      import discretize
+    from mpi4py import MPI
+
+    domain = Line()
+    V = ScalarFunctionSpace('V', domain)
+
+    u = element_of(V, name='u')
+    v = element_of(V, name='v')    
+
+    a = BilinearForm((u, v), integral(domain, u * v))
+    comm = MPI.COMM_WORLD
+    domain_h = discretize(domain, ncells=[n1], periodic=[P1], comm=comm)
+    Vh = discretize(V, domain_h, degree=[p1])
+    ah = discretize(a, domain_h, [Vh, Vh], backend=PSYDAC_BACKENDS['pyccel-gcc'])    
+    M = ah.assemble()
+
+    x = Vh.vector_space.zeros()
+
+    s1, = Vh.vector_space.starts
+    e1, = Vh.vector_space.ends
+
+    # Fill in vector with random values, then update ghost regions
+    for i1 in range(s1, e1 + 1):
+        x[i1] = 2.0 * random() - 1.0
+    x.update_ghost_regions()
+
+    y = M.dot(x)
+    
+    # Convert stencil matrix to PETSc.Mat
+    Mp = M.topetsc()
+
+    #print('\nMp.getSizes()=', Mp.getSizes())
+    # Create Vec to allocate the result of the dot product
+    y_petsc = Mp.createVecLeft()
+    #print('y_petsc.getSizes()=', y_petsc.getSizes())
+
+    x_petsc = x.topetsc()
+    # Compute dot product
+    Mp.mult(x_petsc, y_petsc)
+    # Cast result back to Psydac StencilVector format
+    y_p = petsc_to_psydac(y_petsc, Vh.vector_space)
+
+    ################################################
+    # Note 12.03.2024:
+    # Another possibility would be to compare y_petsc.array and y.toarray(). 
+    # However, we cannot do this because PETSc distributes matrices and vectors different than Psydac.
+    # In the future we would like that PETSc uses the partition from Psydac, 
+    # which might involve passing a DM Object.
+    ################################################
+    '''for k in range(comm.Get_size()):
+        if comm.Get_rank() == k:
+            print('\n\nRank ', k)
+            print('x=\n', x.toarray())
+            print('x_petsc=\n', x_petsc.array)
+
+            print('MAX_DIFF=', abs((y-y_p).toarray()).max())
+        comm.Barrier()'''
 
     assert np.allclose(y_p.toarray(), y.toarray(), rtol=1e-12, atol=1e-12)
 
+#test_mass_matrix_1d_parallel_topetsc(12, 3, True)
 # ===============================================================================
 # PARALLEL BACKENDS TESTS
 # ===============================================================================

--- a/psydac/linalg/tests/test_stencil_vector.py
+++ b/psydac/linalg/tests/test_stencil_vector.py
@@ -431,7 +431,6 @@ def test_stencil_vector_2d_serial_topetsc(dtype, n1, n2, p1, p2, s1, s2, P1, P2)
     x = StencilVector(V)
 
     # Fill the vector with data
-
     if dtype == complex:
         f = lambda i1, i2: 10j * i1 + i2
     else:
@@ -455,7 +454,7 @@ def test_stencil_vector_2d_serial_topetsc(dtype, n1, n2, p1, p2, s1, s2, P1, P2)
     assert v._data.shape == (n1 + 2 * p1 * s1, n2 + 2 * p2 * s2)
     assert v._data.dtype == dtype
     assert np.array_equal(x.toarray(), v.toarray())
-#test_stencil_vector_2d_serial_topetsc(float, 4,5,1,1,1,1,True,True)
+
 # ===============================================================================
 @pytest.mark.parametrize('dtype', [float, complex])
 @pytest.mark.parametrize('n1', [5, 7])
@@ -637,7 +636,6 @@ def test_stencil_vector_2d_parallel_topetsc(dtype, n1, n2, p1, p2, s1, s2, P1, P
 
     assert np.array_equal(x.toarray(), v.toarray())
     
-#test_stencil_vector_2d_parallel_topetsc(float, 4, 5, 1, 1, 1, 1, True, True)   
 # ===============================================================================
 @pytest.mark.parametrize('dtype', [float, complex])
 @pytest.mark.parametrize('n1', [20, 32])
@@ -679,7 +677,6 @@ def test_stencil_vector_1d_parallel_topetsc(dtype, n1, p1, s1, P1):
     v = petsc_to_psydac(v, V)
 
     assert np.array_equal(x.toarray(), v.toarray())
-#test_stencil_vector_1d_parallel_topetsc(float, 7, 2, 2, False)
 
 # ===============================================================================
 @pytest.mark.parametrize('dtype', [float, complex])

--- a/psydac/linalg/tests/test_stencil_vector.py
+++ b/psydac/linalg/tests/test_stencil_vector.py
@@ -731,7 +731,6 @@ def test_stencil_vector_3d_parallel_topetsc(dtype, n1, n2, n3, p1, p2, p3, s1, s
     v = petsc_to_psydac(v, V)
 
     assert np.array_equal(x.toarray(), v.toarray())
-#test_stencil_vector_3d_parallel_topetsc(float, 4, 10, 5, 1, 1, 3, 1, 2, 1, True, True, True)
 
 # ===============================================================================
 @pytest.mark.parametrize('dtype', [float, complex])

--- a/psydac/linalg/topetsc.py
+++ b/psydac/linalg/topetsc.py
@@ -27,29 +27,7 @@ def get_index_shift_per_block_per_process(V):
 
     return index_shift_per_block_per_process #Global variable indexed as [b][k] fo block b, process k
 
-def toIJVrowmap(mat_block, bd, bc, I, J, V, rowmap, dspace, cspace, order='C'):
-
-    '''# Get the number of points per block, per process and per dimension:
-    dnpts_local_per_block_per_process = np.array(get_npts_per_block(dspace)) #indexed [b,k,d] for block b and process k and dimension d
-    cnpts_local_per_block_per_process = np.array(get_npts_per_block(cspace)) 
-    # Get the local sizes per block and per process:
-    dlocal_sizes_per_block_per_process = np.prod(dnpts_local_per_block_per_process, axis=-1) #indexed [b,k] for block b and process k
-    clocal_sizes_per_block_per_process = np.prod(cnpts_local_per_block_per_process, axis=-1)
-
-    dn_blocks = dnpts_local_per_block_per_process.shape[0]
-    dn_procs = dnpts_local_per_block_per_process.shape[1]
-    dindex_shift = [[0 + np.sum(dlocal_sizes_per_block_per_process[:,:k]) + np.sum(dlocal_sizes_per_block_per_process[:b,k]) for k in range(dn_procs)] for b in range(dn_blocks)]
-
-    cn_blocks = cnpts_local_per_block_per_process.shape[0]
-    cn_procs = cnpts_local_per_block_per_process.shape[1]
-    cindex_shift = [[0 + np.sum(clocal_sizes_per_block_per_process[:,:k]) + np.sum(clocal_sizes_per_block_per_process[:b,k]) for k in range(cn_procs)] for b in range(cn_blocks)]
-    '''
-
-    dnpts_local_per_block_per_process = np.array(get_npts_per_block(dspace))
-    cnpts_local_per_block_per_process = np.array(get_npts_per_block(cspace))
-
-    dindex_shift = get_index_shift_per_block_per_process(dspace)
-    cindex_shift = get_index_shift_per_block_per_process(cspace)
+def toIJVrowmap(mat_block, bd, bc, I, J, V, rowmap, dspace, cspace, dnpts_block, cnpts_block, dshift_block, cshift_block, order='C'):
     # Extract Cartesian decomposition of the Block where the node is:
     dspace_block = dspace if isinstance(dspace, StencilVectorSpace) else dspace.spaces[bd]
     cspace_block = cspace if isinstance(cspace, StencilVectorSpace) else cspace.spaces[bc]       
@@ -60,34 +38,30 @@ def toIJVrowmap(mat_block, bd, bc, I, J, V, rowmap, dspace, cspace, order='C'):
     cs = [np.int64(s) for s in cspace_block.cart.starts]
     cp = [np.int64(p) for p in cspace_block.cart.pads]
     cm = [np.int64(m) for m in cspace_block.cart.shifts]
-    dsh = np.array(dindex_shift[bd], dtype='int64') #[np.array(sh, dtype='int64') for sh in dindex_shift[bd]]
-    csh = np.array(cindex_shift[bc], dtype='int64') #[np.array(sh, dtype='int64') for sh in cindex_shift[bc]]
+    dsh = np.array(dshift_block, dtype='int64')
+    csh = np.array(cshift_block, dtype='int64')
 
     dgs = [np.array(gs, dtype='int64') for gs in dspace_block.cart.global_starts] # Global variable
     dge = [np.array(ge, dtype='int64') for ge in dspace_block.cart.global_ends] # Global variable
     cgs = [np.array(gs, dtype='int64') for gs in cspace_block.cart.global_starts] # Global variable
     cge = [np.array(ge, dtype='int64') for ge in cspace_block.cart.global_ends] # Global variable
 
-    #dnlb = [np.array(n, dtype='int64') for n in dnpts_local_per_block_per_process[bd]] 
-    #cnlb = [np.array(n, dtype='int64') for n in cnpts_local_per_block_per_process[bc]] 
-
-    dnlb = [np.array([n[d] for n in dnpts_local_per_block_per_process[bd]], dtype='int64') for d in range(dspace_block.cart.ndim)] 
-    cnlb = [np.array([n[d] for n in cnpts_local_per_block_per_process[bc]] , dtype='int64') for d in range(cspace_block.cart.ndim)]
+    dnlb = [np.array([n[d] for n in dnpts_block], dtype='int64') for d in range(dspace_block.cart.ndim)] 
+    cnlb = [np.array([n[d] for n in cnpts_block] , dtype='int64') for d in range(cspace_block.cart.ndim)]
 
     # Range of data owned by local process (no ghost regions)
     local = tuple( [slice(m*p,-m*p) for p,m in zip(cp, cm)] + [slice(None)] * dspace_block.cart.ndim )
     shape  = mat_block._data[local].shape
-    
     nrows = np.prod(shape[0:dspace_block.cart.ndim])
     nentries = np.prod(shape)
-    # I, J, V, rowmap storage
+
+    # locally block I, J, V, rowmap storage
     Ib = np.zeros(nrows + 1, dtype='int64')
     Jb = np.zeros(nentries, dtype='int64')
     rowmapb = np.zeros(nrows, dtype='int64')
     Vb = np.zeros(nentries, dtype=mat_block._data.dtype)
 
     Ib[0] += I[-1]
-
 
     stencil2IJV = kernels['stencil2IJV'][order][dspace_block.cart.ndim]
 
@@ -177,8 +151,8 @@ def petsc_local_to_psydac(
 
 def psydac_to_petsc_global(
         V : VectorSpace, 
-        block_indices : 'tuple[int]', 
-        ndarray_indices : 'tuple[int]') -> int:
+        block_indices, 
+        ndarray_indices) -> int:
     """
     Convert the Psydac local index (natural multi-index, as grid coordinates) to a PETSc global index. Performs a search to find the process owning the multi-index.
 
@@ -294,7 +268,7 @@ def get_npts_local(V : VectorSpace) -> list:
     --------
     list
         Local number of nodes per dimension owned by the actual process.
-        In case of a StencilVectorSpace the list has length equal the number of dimensions in the domain.
+        In case of a StencilVectorSpace the list contains a single list with length equal the number of dimensions in the domain.
         In case of a BlockVectorSpace the list has length equal the number of blocks.
     """        
     if isinstance(V, StencilVectorSpace):
@@ -463,53 +437,43 @@ def mat_topetsc( mat ):
 
     assert isinstance(mat, StencilMatrix) or isinstance(mat, BlockLinearOperator), 'Conversion only implemented for StencilMatrix and BlockLinearOperator.'
 
-
     if (isinstance(mat.domain, BlockVectorSpace) and any([isinstance(mat.domain.spaces[b], BlockVectorSpace) for b in range(len(mat.domain.spaces))]))\
         or (isinstance(mat.codomain, BlockVectorSpace) and any([isinstance(mat.codomain.spaces[b], BlockVectorSpace) for b in range(len(mat.codomain.spaces))])):
         raise NotImplementedError('Conversion for block of blocks not implemented.')
 
-
-
     if isinstance(mat.domain, StencilVectorSpace):
-        dcarts = [mat.domain.cart]
+        comm = mat.domain.cart.global_comm
     elif isinstance(mat.domain, BlockVectorSpace):
-        dcarts = []
-        for b in range(len(mat.domain.spaces)):
-                dcarts.append(mat.domain.spaces[b].cart)
-
-    if isinstance(mat.codomain, StencilVectorSpace):
-        ccarts = [mat.codomain.cart]
-    elif isinstance(mat.codomain, BlockVectorSpace):
-        ccarts = []
-        for b in range(len(mat.codomain.spaces)):
-                ccarts.append(mat.codomain.spaces[b].cart)
+        comm = mat.domain.spaces[0].cart.global_comm
 
     nonzero_block_indices = ((0,0),) if isinstance(mat, StencilMatrix) else mat.nonzero_block_indices
 
     mat.update_ghost_regions()
     mat.remove_spurious_entries()
 
-    # Number of dimensions for each cart:
-    dndims = [dcart.ndim for dcart in dcarts]
-    cndims = [ccart.ndim for ccart in ccarts]
-    # Get global number of points per block:
-    dnpts =  [dcart.npts for dcart in dcarts] # indexed [block, dimension]. Same for all processes.   
-
     # Get the number of points local to the current process:
     dnpts_local = get_npts_local(mat.domain) # indexed [block, dimension]. Different for each process.
     cnpts_local = get_npts_local(mat.codomain) # indexed [block, dimension]. Different for each process. 
+
+    # Get the number of points per block, per process and per dimension:
+    dnpts_per_block_per_process = np.array(get_npts_per_block(mat.domain)) # global variable, indexed as [block, process, dimension]
+    cnpts_per_block_per_process = np.array(get_npts_per_block(mat.codomain)) # global variable, indexed as [block, process, dimension]
+
+    # Get the index shift for each block and each process:
+    dindex_shift = get_index_shift_per_block_per_process(mat.domain) # global variable, indexed as [block, process, dimension]
+    cindex_shift = get_index_shift_per_block_per_process(mat.codomain) # global variable, indexed as [block, process, dimension]
 
     globalsize = mat.shape
 
     # Sum over the blocks to get the total local size
     localsize = (np.sum(np.prod(cnpts_local, axis=1)), np.sum(np.prod(dnpts_local, axis=1)))
 
-    gmat  = PETSc.Mat().create(comm=dcarts[0].global_comm)
+    gmat  = PETSc.Mat().create(comm=comm)
 
     # Set global and local sizes: size=((local_rows, rows), (local_columns, columns))
     gmat.setSizes(size=((localsize[0], globalsize[0]), (localsize[1], globalsize[1])))
     
-    if dcarts[0].global_comm:
+    if comm:
         # Set PETSc sparse parallel matrix type
         gmat.setType("mpiaij")
     else:
@@ -529,151 +493,62 @@ def mat_topetsc( mat ):
     import time
 
     output = open('output.txt', 'a')
-    comm=dcarts[0].global_comm
 
-    time_loop = np.empty((comm.Get_size(),))
-    time_setValues = np.empty((comm.Get_size(),)) 
-    time_assemble = np.empty((comm.Get_size(),))
+    comm_size = 1 if not comm else comm.Get_size()
+    time_loop = np.empty((comm_size,))
+    time_setValues = np.empty((comm_size,)) 
+    time_assemble = np.empty((comm_size,))
                              
-
     t_prev = time.time()
     for bc, bd in nonzero_block_indices:
         if isinstance(mat, BlockLinearOperator):
             mat_block = mat.blocks[bc][bd]
-        I,J,V,rowmap = toIJVrowmap(mat_block, bd, bc, I, J, V, rowmap, mat.domain, mat.codomain)
+        dnpts_block = dnpts_per_block_per_process[bd]
+        cnpts_block = cnpts_per_block_per_process[bc]
+        dshift_block = dindex_shift[bd]
+        cshift_block = cindex_shift[bc]
 
-    """    cs = ccarts[bc].starts
-        cghost_size = [pi*mi for pi,mi in zip(ccarts[bc].pads, ccarts[bc].shifts)]
+        I,J,V,rowmap = toIJVrowmap(mat_block, bd, bc, I, J, V, rowmap, mat.domain, mat.codomain, dnpts_block, cnpts_block, dshift_block, cshift_block)
 
-        if dndims[bd] == 1 and cndims[bc] == 1:
-            I,J,V,rowmap = toIJVrowmap(mat_block, bd, bc, I, J, V, rowmap, mat.domain, mat.codomain)
-            '''for i1 in range(cnpts_local[bc][0]):
-                nnz_in_row = 0
-                i1_n = cs[0] + i1
-                i_g = psydac_to_petsc_global(mat.codomain, (bc,), (i1_n,))
 
-                stencil_size = mat_block._data[i1 + cghost_size[0],:].shape
-
-                for k1 in range(stencil_size[0]):
-                    value = mat_block._data[i1 + cghost_size[0], k1]
-
-                    j1_n = (i1_n + k1 - stencil_size[0]//2) % dnpts[bd][0] # modulus is necessary for periodic BC
-                    
-                    if value != 0:
-                        j_g = psydac_to_petsc_global(mat.domain, (bd,), (j1_n, ))
-
-                        if nnz_in_row == 0:
-                            rowmap.append(i_g)  
-
-                        J.append(j_g)           
-                        V.append(value)  
-
-                        nnz_in_row += 1
-
-                if nnz_in_row > 0:
-                    I.append(I[-1] + nnz_in_row)'''
-                
-        elif dndims[bd] == 2 and cndims[bc] == 2:
-            I,J,V,rowmap = toIJVrowmap(mat_block, bd, bc, I, J, V, rowmap, mat.domain, mat.codomain)
-            '''for i1 in np.arange(cnpts_local[bc][0]):              
-                for i2 in np.arange(cnpts_local[bc][1]):
-
-                    nnz_in_row = 0
-
-                    i1_n = cs[0] + i1
-                    i2_n = cs[1] + i2
-                    i_g = psydac_to_petsc_global(mat.codomain, (bc,), (i1_n, i2_n))
-
-                    stencil_size = mat_block._data[i1 + cghost_size[0], i2 + cghost_size[1],:,:].shape
-
-                    for k1 in range(stencil_size[0]):                    
-                        for k2 in range(stencil_size[1]):
-                            value = mat_block._data[i1 + cghost_size[0], i2 + cghost_size[1], k1, k2]
-
-                            j1_n = (i1_n + k1 - stencil_size[0]//2) % dnpts[bd][0] # modulus is necessary for periodic BC
-                            j2_n = (i2_n + k2 - stencil_size[1]//2) % dnpts[bd][1] # modulus is necessary for periodic BC
-
-                            if value != 0:
-                                j_g = psydac_to_petsc_global(mat.domain, (bd,), (j1_n, j2_n))
-
-                                if nnz_in_row == 0:
-                                    rowmap.append(i_g)     
-
-                                J.append(j_g)
-                                V.append(value)  
-
-                                nnz_in_row += 1
-
-                    if nnz_in_row > 0:
-                        I.append(I[-1] + nnz_in_row)'''
-
-        elif dndims[bd] == 3 and cndims[bc] == 3: 
-            for i1 in np.arange(cnpts_local[bc][0]):             
-                for i2 in np.arange(cnpts_local[bc][1]):
-                    for i3 in np.arange(cnpts_local[bc][2]):
-                        nnz_in_row = 0
-                        i1_n = cs[0] + i1
-                        i2_n = cs[1] + i2
-                        i3_n = cs[2] + i3
-                        i_g = psydac_to_petsc_global(mat.codomain, (bc,), (i1_n, i2_n, i3_n))
-
-                        stencil_size = mat_block._data[i1 + cghost_size[0], i2 + cghost_size[1], i3 + cghost_size[2],:,:,:].shape
-
-                        for k1 in range(stencil_size[0]):                    
-                            for k2 in range(stencil_size[1]):
-                                for k3 in range(stencil_size[2]):
-                                    value = mat_block._data[i1 + cghost_size[0], i2 + cghost_size[1], i3 + cghost_size[2], k1, k2, k3]
-
-                                    j1_n = (i1_n + k1 - stencil_size[0]//2) % dnpts[bd][0] # modulus is necessary for periodic BC
-                                    j2_n = (i2_n + k2 - stencil_size[1]//2) % dnpts[bd][1] # modulus is necessary for periodic BC
-                                    j3_n = (i3_n + k3 - stencil_size[2]//2) % dnpts[bd][2] # modulus is necessary for periodic BC
-
-                                    if value != 0:
-                                        j_g = psydac_to_petsc_global(mat.domain, (bd,), (j1_n, j2_n, j3_n))
-
-                                        if nnz_in_row == 0: 
-                                            rowmap.append(i_g)     
-                                
-                                        J.append(j_g)
-                                        V.append(value)  
-
-                                        nnz_in_row += 1
-
-                        if nnz_in_row > 0:
-                            I.append(I[-1] + nnz_in_row)
-    """
-    time_loop[comm.Get_rank()] = time.time() - t_prev
+    comm_rk = 0 if not comm else comm.Get_rank()
+    time_loop[comm_rk] = time.time() - t_prev
 
     print('Time for the loop: ', time.time() - t_prev)
     t_prev = time.time()
     # Set the values using IJV&rowmap format. The values are stored in a cache memory.
     gmat.setValuesIJV(I, J, V, rowmap=rowmap, addv=PETSc.InsertMode.ADD_VALUES) # The addition mode is necessary when periodic BC
 
-    time_setValues[comm.Get_rank()] = time.time() - t_prev
+    time_setValues[comm_rk] = time.time() - t_prev
 
     print('Time for the setValuesIJV: ', time.time() - t_prev)
 
     t_prev = time.time()
     # Assemble the matrix with the values from the cache. Here it is where PETSc exchanges global communication.
     gmat.assemble()
-    time_assemble[comm.Get_rank()] = time.time() - t_prev
+    time_assemble[comm_rk] = time.time() - t_prev
     print('Time for the assemble: ', time.time() - t_prev)
 
+    if comm_rk == 0:
+        print(f'\nnprocs={comm_size}\nProcess & global size & local size & Time loop & Time setValuesIJV & Time assemble ', file=output, flush=True)
 
-    if comm.Get_rank() == 0:
-        print(f'\nProcess & global size & local size & Time loop & Time setValuesIJV & Time assemble ', file=output, flush=True)
-
-    for k in range(comm.Get_size()):
-        if k == comm.Get_rank():
+    for k in range(comm_size):
+        if k == comm_rk:
             ls, gs = gmat.getSizes()[0]
             print(f'{k} & {gs} & {ls} & {time_loop[k]:.2f} & {time_setValues[k]:.2f} & {time_assemble[k]:.2f}', file=output, flush=True)
-        comm.Barrier()
+        if comm:
+            comm.Barrier()
 
-    avg_time_loop = comm.reduce(time_loop)
-    avg_time_setValues = comm.reduce(time_setValues, op=MPI.SUM, root=0)
-    avg_time_assemble = comm.reduce(time_assemble, op=MPI.SUM, root=0)
+    if comm:
+        avg_time_loop = comm.reduce(time_loop)
+        avg_time_setValues = comm.reduce(time_setValues, op=MPI.SUM, root=0)
+        avg_time_assemble = comm.reduce(time_assemble, op=MPI.SUM, root=0)
+    else:
+        avg_time_loop = time_loop
+        avg_time_setValues = time_setValues
+        avg_time_assemble = time_assemble  
     
-    if comm.Get_rank() == 0:
+    if comm_rk == 0:
         print(f'Average & {np.mean(avg_time_loop):.2f} & {np.mean(avg_time_setValues):.2f} & {np.mean(avg_time_assemble):.2f}', file=output, flush=True)   
 
     output.close() 

--- a/psydac/linalg/topetsc.py
+++ b/psydac/linalg/topetsc.py
@@ -177,8 +177,8 @@ def petsc_local_to_psydac(
 
 def psydac_to_petsc_global(
         V : VectorSpace, 
-        block_indices : tuple[int], 
-        ndarray_indices : tuple[int]) -> int:
+        block_indices : 'tuple[int]', 
+        ndarray_indices : 'tuple[int]') -> int:
     """
     Convert the Psydac local index (natural multi-index, as grid coordinates) to a PETSc global index. Performs a search to find the process owning the multi-index.
 

--- a/psydac/linalg/topetsc.py
+++ b/psydac/linalg/topetsc.py
@@ -294,9 +294,15 @@ def get_npts_local(V : VectorSpace) -> list:
         s = V.starts
         e = V.ends        
         npts_local = [ e - s + 1 for s, e in zip(s, e)] #Number of points in each dimension within each process. Different for each process.
-        return npts_local
+        return [npts_local]
 
-    npts_local_per_block = [ get_npts_local(V.spaces[b]) for b in range(V.n_blocks) ]
+    npts_local_per_block = []
+    for b in range(V.n_blocks):
+        npts_local_b = get_npts_local(V.spaces[b])
+        if isinstance(V.spaces[b], StencilVectorSpace):
+            npts_local_b = npts_local_b[0]
+        npts_local_per_block.append(npts_local_b)
+    #npts_local_per_block = [ get_npts_local(V.spaces[b]) for b in range(V.n_blocks) ]
     return npts_local_per_block
 
 def get_block_local_shift(V : VectorSpace) -> np.ndarray:
@@ -590,7 +596,7 @@ def vec_topetsc( vec ):
     for k in range(comms[0].Get_size()):
         if k == comms[0].Get_rank():
             print(f'Rank {k}: vec={vec_arr}, petsc_indices={petsc_indices}, data={petsc_data}, s={s}, npts_local={npts_local}, gvec={gvec.array.real}')
-        comms[k].Barrier()    
+        comms[0].Barrier()    
 
     return gvec
 

--- a/psydac/linalg/topetsc.py
+++ b/psydac/linalg/topetsc.py
@@ -2,11 +2,132 @@ import numpy as np
 
 from psydac.linalg.block import BlockVectorSpace, BlockVector
 from psydac.linalg.stencil import StencilVectorSpace, StencilVector, StencilMatrix
+from psydac.linalg.basic import VectorSpace
 from scipy.sparse import coo_matrix, bmat
+from itertools import product as cartesian_prod
 
 from mpi4py import MPI
 
 __all__ = ('flatten_vec', 'vec_topetsc', 'mat_topetsc')
+
+
+def psydac_to_petsc_local(
+     V : VectorSpace,
+     block_indices : tuple[int],
+     ndarray_indices : tuple[int]) -> int :
+    """
+    Convert the Psydac local index to a PETSc local index.
+
+    Parameters
+    -----------
+    V : VectorSpace
+        The vector space to which the Psydac vector belongs.
+        This defines the number of blocks, the size of each block,
+        and how each block is distributed across MPI processes.
+
+    block_indices : tuple[int]
+        The indices which identify the block in a (possibly nested) block vector.
+        In the case of a StencilVector this is an empty tuple.
+
+    ndarray_indices : tuple[int]
+        The multi-index which identifies an element in the _data array,
+        excluding the ghost regions.
+
+    Returns
+    --------
+    petsc_index : int
+        The local PETSc index, which is equivalent to the global PETSc index
+        but starts from 0. 
+    """
+
+    ndim = V.ndim
+    starts = V.starts
+    ends = V.ends
+    pads = V.pads
+    shifts = V.shifts
+    shape = V.shape
+
+    ii = ndarray_indices
+
+
+    npts_local = [ e - s + 1 for s, e in zip(starts, ends)] #Number of points in each dimension within each process. Different for each process.
+    
+    assert all([ii[d] >= pads[d]*shifts[d] and ii[d] < shape[d] - pads[d]*shifts[d] for d in range(ndim)]), 'ndarray_indices within the ghost region'
+
+    if ndim == 1:
+        petsc_index = ii[0] - pads[0]*shifts[0] # global index starting from 0 in each process
+    elif ndim == 2:
+        petsc_index = npts_local[1] * (ii[0] - pads[0]*shifts[0]) + ii[1] - pads[1]*shifts[1] # global index starting from 0 in each process
+    elif ndim == 3:
+        petsc_index = npts_local[1] * npts_local[2] * (ii[0] - pads[0]*shifts[0]) + npts_local[2] * (ii[1] - pads[1]*shifts[1]) + ii[2] - pads[2]*shifts[2]
+    else:
+        raise NotImplementedError( "Cannot handle more than 3 dimensions." )
+    
+    return petsc_index
+
+def get_petsc_local_to_global_shift(V : VectorSpace) -> int:
+    """
+    Compute the correct integer shift (process dependent) in order to convert
+    a PETSc local index to the corresponding global index.
+
+    Parameter
+    ---------
+    V : VectorSpace
+        The distributed Psydac vector space.
+
+    Returns
+    --------
+    int
+        The integer shift which must be added to a local index
+        in order to get a global index.
+    """
+
+    cart = V.cart
+    comm = cart.global_comm
+    gstarts = cart.global_starts # Global variable
+    gends = cart.global_ends # Global variable
+
+    npts_local_perprocess = [ ge - gs + 1 for gs, ge in zip(gstarts, gends)] #Global variable
+    npts_local_perprocess = [*cartesian_prod(*npts_local_perprocess)] #Global variable
+    localsize_perprocess = [np.prod(npts_local_perprocess[k]) for k in range(comm.Get_size())] #Global variable
+    index_shift = 0 + np.sum(localsize_perprocess[0:comm.Get_rank()], dtype=int) #Global variable
+
+    return index_shift
+
+def petsc_to_psydac_local(
+    V : VectorSpace,
+    petsc_index : int) :#-> tuple(tuple[int], tuple[int]) :
+    """
+    Convert the PETSc local index to a Psydac local index.
+    This is the inverse of `psydac_to_petsc_local`.
+    """
+
+    ndim = V.ndim
+    starts = V.starts
+    ends = V.ends
+    pads = V.pads
+    shifts = V.shifts    
+
+    npts_local = [ e - s + 1 for s, e in zip(starts, ends)] #Number of points in each dimension within each process. Different for each process.
+
+    ii = np.zeros((ndim,), dtype=int)
+    if ndim == 1:
+        ii[0] = petsc_index + pads[0]*shifts[0] # global index starting from 0 in each process
+
+    elif ndim == 2:
+        ii[0] = petsc_index // npts_local[1] + pads[0]*shifts[0]
+        ii[1] = petsc_index % npts_local[1] + pads[1]*shifts[1]
+
+    elif ndim == 3:
+        ii[0] = petsc_index // (npts_local[1]*npts_local[2]) + pads[0]*shifts[0]
+        ii[1] = petsc_index // npts_local[2] + pads[1]*shifts[1] - npts_local[1]*(ii[0] - pads[0]*shifts[0])
+        ii[2] = petsc_index % npts_local[2] + pads[2]*shifts[2]
+
+    else:
+        raise NotImplementedError( "Cannot handle more than 3 dimensions." )
+
+    return [tuple(ii)]
+
 
 def flatten_vec( vec ):
     """ Return the flattened 1D array values and indices owned by the process of the given vector.
@@ -73,23 +194,166 @@ def vec_topetsc( vec ):
     from petsc4py import PETSc
 
     if isinstance(vec, StencilVector):
-        comm = vec.space.cart.global_comm
+        cart = vec.space.cart
     elif isinstance(vec.space.spaces[0], StencilVectorSpace):
-        comm = vec.space.spaces[0].cart.global_comm
+        cart = vec.space.spaces[0].cart
     elif isinstance(vec.space.spaces[0], BlockVectorSpace):
-        comm = vec.space.spaces[0][0].cart.global_comm
+        cart = vec.space.spaces[0][0].cart
 
-    globalsize = vec.space.dimension
+    comm = cart.global_comm
+    globalsize = vec.space.dimension #integer
+    """    print('\n\nVEC:\nglobalsize=', globalsize)    
+    gvec.setDM(Dmda)
+
+    # Set local and global size
+    gvec.setSizes(size=(ownership_ranges[comm.Get_rank()], globalsize))
+
+    '''ownership_ranges = [comm.allgather(cart.domain_decomposition.local_ncells[k]) for k in range(cart.ndim)]
+    boundary_type = [(PETSc.DM.BoundaryType.PERIODIC if cart.domain_decomposition.periods[k] else PETSc.DM.BoundaryType.NONE) for k in range(cart.ndim)]
+
+    #ownership_ranges = [ dcart.global_ends[0][k] - dcart.global_starts[0][k] + 1 for k in range(dcart.global_starts[0].size)]
+    print('VECTOR: OWNership_ranges=', ownership_ranges)
+    #Dmda = PETSc.DMDA().create(dim=2, sizes=mat.shape, proc_sizes=(comm.Get_size(),1), ownership_ranges=(ownership_ranges, mat.shape[1]), comm=comm)
+    # proc_sizes = [ len]
+    Dmda = PETSc.DMDA().create(dim=cart.ndim, sizes=cart.domain_decomposition.ncells, proc_sizes=cart.domain_decomposition.nprocs, 
+                               ownership_ranges=ownership_ranges, comm=comm, stencil_type=PETSc.DMDA.StencilType.BOX, boundary_type=boundary_type)'''
+    
+    ### SPLITTING COEFFS
+    ownership_ranges = [ 1 + cart.global_ends[0][k] - cart.global_starts[0][k] for k in range(cart.global_starts[0].size)] 
+    #ownership_ranges = [comm.allgather(dcart.domain_decomposition.local_ncells[k]) for k in range(dcart.ndim)]
+    
+    print('OWNership_ranges=', ownership_ranges)
+    print('dcart.domain_decomposition.nprocs=', *cart.domain_decomposition.nprocs)
+
+    boundary_type = [(PETSc.DM.BoundaryType.PERIODIC if cart.domain_decomposition.periods[k] else PETSc.DM.BoundaryType.NONE) for k in range(cart.ndim)]
+
+    Dmda = PETSc.DMDA().create(dim=1, sizes=(globalsize,), proc_sizes=cart.domain_decomposition.nprocs, comm=comm, 
+                               ownership_ranges=[ownership_ranges], boundary_type=boundary_type)
+    
+
     indices, data = flatten_vec(vec)
-    gvec  = PETSc.Vec().create(comm=comm)
-    # Set global size
-    gvec.setSizes(globalsize)
-    gvec.setFromOptions()
-    # Set values of the vector. They are stored in a cache, so the assembly is necessary to use the vector.
-    gvec.setValues(indices, data)
+    for k in range(comm.Get_size()):
+        if comm.Get_rank() == k:
+            print('Rank ', k)
+            print('vec.toarray()=\n', vec.toarray())
+            print('VEC_indices=', indices)
+            print('VEC_data=', data)
+        comm.Barrier()
 
+
+
+    gvec  = PETSc.Vec().create(comm=comm)
+
+    gvec.setDM(Dmda)
+
+    # Set local and global size
+    gvec.setSizes(size=(ownership_ranges[comm.Get_rank()], globalsize))
+
+    '''if comm:
+        cart_petsc = cart.topetsc()
+        gvec.setLGMap(cart_petsc.l2g_mapping)'''
+
+
+    gvec.setFromOptions()
+    gvec.setUp()
+    # Set values of the vector. They are stored in a cache, so the assembly is necessary to use the vector.
+    gvec.setValues(indices, data, addv=PETSc.InsertMode.ADD_VALUES)"""
+
+    ndim = vec.space.ndim
+    starts = vec.space.starts
+    ends = vec.space.ends
+    pads = vec.space.pads
+    shifts = vec.space.shifts
+    #npts = vec.space.npts
+
+    #cart = vec.space.cart
+
+    npts_local = [ e - s + 1 for s, e in zip(starts, ends)] #Number of points in each dimension within each process. Different for each process.
+    '''npts_local_perprocess = [ ge - gs + 1 for gs, ge in zip(cart.global_starts, cart.global_ends)] #Global variable
+    npts_local_perprocess = [*cartesian_prod(*npts_local_perprocess)] #Global variable
+    localsize_perprocess = [np.prod(npts_local_perprocess[k]) for k in range(comm.Get_size())] #Global variable'''
+    index_shift = get_petsc_local_to_global_shift(vec.space) #Global variable
+
+    '''for k in range(comm.Get_size()):
+        if k == comm.Get_rank():   
+            print('\nRank ', k)
+            print('starts=', starts)
+            print('ends=', ends)
+            print('npts=', npts)
+            print('pads=', pads)
+            print('shifts=', shifts)
+            print('npts_local=', npts_local)
+            print('cart.global_starts=', cart.global_starts)
+            print('cart.global_ends=', cart.global_ends)
+            print('npts_local_perprocess=', npts_local_perprocess)
+            print('localsize_perprocess=', localsize_perprocess)
+            print('index_shift=', index_shift)
+
+            print('vec._data.shape=', vec._data.shape)
+            print('vec._data=', vec._data)
+            #print('vec.toarray()=', vec.toarray())
+        comm.Barrier()'''
+
+    gvec  = PETSc.Vec().create(comm=comm)
+
+    localsize = np.prod(npts_local)
+    gvec.setSizes(size=(localsize, globalsize))#size=(ownership_ranges[comm.Get_rank()], globalsize))
+
+    gvec.setFromOptions()
+    gvec.setUp()
+
+    petsc_indices = []
+    petsc_data = []
+
+    if ndim == 1:
+        for i1 in range(pads[0]*shifts[0], pads[0]*shifts[0] + npts_local[0]):
+            value = vec._data[i1]
+            if value != 0:
+                index = psydac_to_petsc_local(vec.space, [], (i1)) # global index starting from 0 in each process
+                index += index_shift #starts[0] # global index starting from NOT 0 in each process
+                petsc_indices.append(index)
+                petsc_data.append(value)        
+
+    elif ndim == 2:
+        for i1 in range(pads[0]*shifts[0], pads[0]*shifts[0] + npts_local[0]):
+            for i2 in range(pads[1]*shifts[1], pads[1]*shifts[1] + npts_local[1]):
+                value = vec._data[i1,i2]
+                if value != 0:
+                    #index = npts_local[1] * (i1 - pads[0]*shifts[0]) + i2 - pads[1]*shifts[1] # global index starting from 0 in each process
+                    index = psydac_to_petsc_local(vec.space, [], (i1,i2)) # global index starting from 0 in each process
+                    index += index_shift # global index starting from NOT 0 in each process
+                    petsc_indices.append(index)
+                    petsc_data.append(value)
+
+    elif ndim == 3:
+        for i1 in range(pads[0]*shifts[0], pads[0]*shifts[0] + npts_local[0]):
+            for i2 in range(pads[1]*shifts[1], pads[1]*shifts[1] + npts_local[1]):
+                for i3 in range(pads[2]*shifts[2], pads[2]*shifts[2] + npts_local[2]):
+                    value = vec._data[i1, i2, i3]
+                    if value != 0:
+                        #index = npts_local[1] * npts_local[2] * (i1 - pads[0]*shifts[0]) + npts_local[2] * (i2 - pads[1]*shifts[1]) + i3 - pads[2]*shifts[2]
+                        index = psydac_to_petsc_local(vec.space, [], (i1,i2,i3)) 
+                        index += index_shift # global index starting from NOT 0 in each process
+                        petsc_indices.append(index)
+                        petsc_data.append(value)        
+
+    gvec.setValues(petsc_indices, petsc_data, addv=PETSc.InsertMode.ADD_VALUES)
     # Assemble vector
     gvec.assemble() # Here PETSc exchanges global communication. The block corresponding to a certain process is not necessarily the same block in the Psydac StencilVector.
+    #diff = abs(vec.toarray() - gvec.array).max()
+
+    '''vec_arr = vec.toarray()
+
+    for k in range(comm.Get_size()):
+        if k == comm.Get_rank():   
+            print('\nRank ', k)
+            print('petsc_indices=', petsc_indices)
+            print('petsc_data=', petsc_data)
+            print('\ngvec.array=', gvec.array.real)
+            print('vec.toarray()=', vec_arr)
+        comm.Barrier()'''
+
+    
     return gvec
 
 def mat_topetsc( mat ):
@@ -109,42 +373,262 @@ def mat_topetsc( mat ):
     from petsc4py import PETSc
 
     if isinstance(mat, StencilMatrix):
-        comm = mat.domain.cart.global_comm
+        dcart = mat.domain.cart
+        ccart = mat.codomain.cart
     elif isinstance(mat.domain.spaces[0], StencilVectorSpace):
-        comm = mat.domain.spaces[0].cart.global_comm
+        dcart = mat.domain.spaces[0].cart
+        ccart = mat.codomain.spaces[0].cart
     elif isinstance(mat.domain.spaces[0], BlockVectorSpace):
-        comm = mat.domain.spaces[0][0].cart.global_comm
+        dcart = mat.domain.spaces[0][0].cart
+        ccart = mat.codomain.spaces[0][0].cart
 
-    mat_coo = mat.tosparse()
+    comm = dcart.global_comm
 
+
+
+    #print('mat.shape = ', mat.shape)
+    #print('rank: ', comm.Get_rank(), ', local_ncells=', dcart.domain_decomposition.local_ncells)
+    #print('rank: ', comm.Get_rank(), ', nprocs=', dcart.domain_decomposition.nprocs)
+
+
+    #recvbuf = np.empty(shape=(dcart.domain_decomposition.nprocs[0],1))
+    #comm.allgather(sendbuf=dcart.domain_decomposition.local_ncells, recvbuf=recvbuf)
+    
+    ####################################
+    
+    ### SPLITTING DOMAIN
+    #ownership_ranges = [comm.allgather(dcart.domain_decomposition.local_ncells[k]) for k in range(dcart.ndim)]
+    
+    boundary_type = [(PETSc.DM.BoundaryType.PERIODIC if mat.domain.periods[k] else PETSc.DM.BoundaryType.NONE) for k in range(dcart.ndim)]
+
+
+    dim = dcart.ndim
+    sizes = dcart.npts
+    proc_sizes = dcart.nprocs
+    #ownership_ranges = [[ 1 + dcart.global_ends[p][k] - dcart.global_starts[p][k] 
+    #                                                    for k in range(dcart.global_starts[p].size)] 
+    #                                                        for p in range(len(dcart.global_starts))]
+    ownership_ranges = [[e - s + 1 for s,e in zip(starts, ends)] for starts, ends in zip(dcart.global_starts, dcart.global_ends)]
+    print('OWNership_ranges=', ownership_ranges)
+    Dmda = PETSc.DMDA().create(dim=dim, sizes=sizes, proc_sizes=proc_sizes, 
+                               ownership_ranges=ownership_ranges, comm=comm, 
+                               stencil_type=PETSc.DMDA.StencilType.BOX, boundary_type=boundary_type)
+    
+
+    '''### SPLITTING COEFFS
+    ownership_ranges = [[ 1 + dcart.global_ends[p][k] - dcart.global_starts[p][k] for k in range(dcart.global_starts[p].size)] for p in range(len(dcart.global_starts))]
+    #ownership_ranges = [comm.allgather(dcart.domain_decomposition.local_ncells[k]) for k in range(dcart.ndim)]
+    
+    print('MAT: ownership_ranges=', ownership_ranges)
+    print('MAT: dcart.domain_decomposition.nprocs=', *dcart.domain_decomposition.nprocs)
+
+    boundary_type = [(PETSc.DM.BoundaryType.PERIODIC if mat.domain.periods[k] else PETSc.DM.BoundaryType.NONE) for k in range(dcart.ndim)]
+
+    Dmda = PETSc.DMDA().create(dim=1, sizes=mat.shape, proc_sizes=[*dcart.domain_decomposition.nprocs,1], comm=comm, 
+                               ownership_ranges=[ownership_ranges[0], [mat.shape[1]]], stencil_type=PETSc.DMDA.StencilType.BOX, boundary_type=boundary_type)
+    '''
+
+    '''    if comm:
+        dcart_petsc = dcart.topetsc()
+        d_LG_map    = dcart_petsc.l2g_mapping
+
+        ccart_petsc = ccart.topetsc()
+        c_LG_map    = ccart_petsc.l2g_mapping
+
+        print('Rank', comm.Get_rank(), ': dcart_petsc.local_size = ', dcart_petsc.local_size)
+        print('Rank', comm.Get_rank(), ': dcart_petsc.local_shape = ', dcart_petsc.local_shape)
+        print('Rank', comm.Get_rank(), ': ccart_petsc.local_size = ', ccart_petsc.local_size)
+        print('Rank', comm.Get_rank(), ': ccart_petsc.local_shape = ', ccart_petsc.local_shape)
+
+    if not comm:
+        print('')
+    else:
+        for k in range(comm.Get_size()):
+            if comm.Get_rank() == k:
+                print('\nRank ', k)
+                print('mat=\n', mat.tosparse().toarray())
+                print('dcart.local_ncells=', dcart.domain_decomposition.local_ncells)
+                print('ccart.local_ncells=', ccart.domain_decomposition.local_ncells)
+                print('dcart._grids=', dcart._grids)
+                print('ccart._grids=', ccart._grids)
+                print('dcart.starts =', dcart.starts)
+                print('dcart.ends =', dcart.ends)
+                print('ccart.starts =', ccart.starts)
+                print('ccart.ends =', ccart.ends)
+                print('dcart.shape=', dcart.shape)
+                print('dcart.npts=', dcart.npts)
+                print('ccart.shape=', ccart.shape)
+                print('ccart.npts=', ccart.npts)
+                print('\ndcart.indices=', dcart_petsc.indices)
+                print('ccart.indices=', ccart_petsc.indices)
+                print('dcart.global_starts=', dcart.global_starts)
+                print('dcart.global_ends=', dcart.global_ends)
+                print('ccart.global_starts=', ccart.global_starts)
+                print('ccart.global_ends=', ccart.global_ends)
+            comm.Barrier()
+    '''
+
+    print('Dmda.getOwnershipRanges()=', Dmda.getOwnershipRanges())
+    print('Dmda.getRanges()=', Dmda.getRanges())
+
+    #LGmap = PETSc.LGMap().create(indices=)
+
+    #dm = PETSc.DM().create(comm=comm)
     gmat  = PETSc.Mat().create(comm=comm)
 
+    gmat.setDM(Dmda)
+    # Set GLOBAL matrix size
+    #gmat.setSizes(mat.shape)
+
+    #gmat.setSizes(size=((dcart.domain_decomposition.local_ncells[0],mat.shape[0]), (mat.shape[1],mat.shape[1])),
+    #              bsize=None)
+    #gmat.setSizes([[dcart_petsc.local_size, mat.shape[0]], [ccart_petsc.local_size, mat.shape[1]]])      #mat.setSizes([[nrl, nrg], [ncl, ncg]])
+    
+    local_rows = np.prod([e - s + 1 for s, e in zip(ccart.starts, ccart.ends)])
+    #local_columns = np.prod([p*m for p, m in zip(mat.domain.pads, mat.domain.shifts)])
+    local_columns = np.prod([e - s + 1 for s, e in zip(dcart.starts, dcart.ends)])    
+    rows = mat.shape[0]
+    columns = mat.shape[1]
+    gmat.setSizes(size=((local_rows, rows), (local_columns, columns))) #((local_rows, rows), (local_columns, columns))
+    
     if comm:
         # Set PETSc sparse parallel matrix type
         gmat.setType("mpiaij")
+        #gmat.setLGMap(c_LG_map, d_LG_map)
     else:
         # Set PETSc sequential matrix type
         gmat.setType("seqaij")
 
-    # Set GLOBAL matrix size
-    gmat.setSizes(mat.shape)        
     gmat.setFromOptions()
+    gmat.setUp()
 
-    rows, cols, data = mat_coo.row, mat_coo.col, mat_coo.data
+    print('gmat.getSizes()=', gmat.getSizes())
 
-    if comm:
-        # Preallocate number of nonzeros
-        row_lengths = np.count_nonzero(rows[None,:] == np.unique(rows)[:,None], axis=1).max()
+    mat_coo = mat.tosparse()
+    rows_coo, cols_coo, data_coo = mat_coo.row, mat_coo.col, mat_coo.data
+
+    mat_csr = mat_coo.tocsr()
+    mat_csr.eliminate_zeros()
+    data, indices, indptr = mat_csr.data, mat_csr.indices, mat_csr.indptr
+    #indptr_chunk = indptr[indptr >= dcart.starts[0] and indptr <= dcart.ends[0]]
+    #indices_chunk = indices[indices >= dcart.starts[1] and indices <= dcart.ends[1]]
+
+    mat_coo_local = mat.tocoo_local()
+    rows_coo_local, cols_coo_local, data_coo_local = mat_coo_local.row, mat_coo_local.col, mat_coo_local.data
+
+    local_petsc_index = psydac_to_petsc_local(mat.domain, [], [2,0])
+    global_petsc_index = get_petsc_local_to_global_shift(mat.domain)
+
+
+    print('dcart.global_starts=', dcart.global_starts)
+    print('dcart.global_ends=', dcart.global_ends)
+    
+    '''for k in range(comm.Get_size()):
+        if comm.Get_rank() == k:
+            local_indptr = indptr[1 + dcart.global_starts[0][comm.Get_rank()]:2+dcart.global_ends[0][comm.Get_rank()]]
+            local_indptr = [row_pter - dcart.global_starts[0][comm.Get_rank()] for row_pter in local_indptr]
+            local_indptr = [0, *local_indptr]
+        comm.Barrier()'''
+    
+    '''if comm.Get_rank() == 0:
+        local_indptr = [3,6]
+    else:
+        local_indptr = [3]'''
+    #local_indptr = indptr[1+ dcart.global_starts[comm.Get_rank()][0]:dcart.global_ends[comm.Get_rank()][0]+2]
+    #local_indptr = [0, *local_indptr]
+
+    if not comm:
+        print('178:indptr = ', indptr)
+        print('178:indices = ', indices)
+        print('178:data = ', data)
+    else:
+        for k in range(comm.Get_size()):
+            if comm.Get_rank() == k:
+                print('\nRank ', k)
+                print('mat=\n', mat_csr.toarray())
+                print('CSR: indptr = ', indptr)
+                #print('local_indptr = ', local_indptr)
+                print('CSR: indices = ', indices)
+                print('CSR: data = ', data)  
+
+
+                '''print('data_coo_local=', data_coo_local)
+                print('rows_coo_local=', rows_coo_local)
+                print('cols_coo_local=', cols_coo_local)
+
+                print('data_coo=', data_coo)
+                print('rows_coo=', rows_coo)
+                print('cols_coo=', cols_coo)'''
+
+            comm.Barrier()      
+
+    '''rows, cols, data = mat_coo.row, mat_coo.col, mat_coo.data
+    for k in range(comm.Get_size()):
+        if k == comm.Get_rank():
+            print('\nRank ', k, ': data.size =', data.size)
+            print('rows=', rows)
+            print('cols=', cols)
+            print('data=', data)
+        comm.Barrier()'''
+    
+
+    import time
+    t_prev = time.time() 
+    '''for k in range(len(rows_coo)):
+        gmat.setValues(rows_coo[k] - dcart.global_starts[0][comm.Get_rank()], cols_coo[k], data_coo[k])
+    '''
+    #gmat.setValuesCSR([r - dcart.global_starts[0][comm.Get_rank()] for r in indptr[1:]], indices, data)
+    #gmat.setValuesLocalCSR(local_indptr, indices, data)#, addv=PETSc.InsertMode.ADD_VALUES)
+    
+    r = gmat.Stencil(0,0,0)
+    c = gmat.Stencil(0,0,0)
+    s = np.prod([p*m for p, m in zip(mat.domain.pads, mat.domain.shifts)])
+    print('r=', r)
+    for k in range(comm.Get_size()):
+        if comm.Get_rank() == k:
+            print('\nrank ', k)
+            print('mat._data=', mat._data)
+            
+            print('mat.domain.pads=', mat.domain.pads)
+            print('mat.domain.shifts=', mat.domain.shifts)
+            print('mat._data (without ghost)=', mat._data[s:-s])
+
+        comm.Barrier()
+
+    gmat.setValuesStencil(mat._data[s:-s])
+
+
+    print('Rank ', comm.Get_rank() if comm else '-', ': duration of setValuesCSR :', time.time()-t_prev)
+    
+    '''if comm:
+        # Preallocate number of nonzeros per row
+        #row_lengths = np.count_nonzero(rows[None,:] == np.unique(rows)[:,None], axis=1).max()
+        
+        ##very slow:
+        #row_lengths = 0
+        #for r in np.unique(rows):
+        #    row_lengths = max(row_lengths, np.nonzero(rows==r)[0].size)
+        
+        row_lengths = np.unique(rows, return_counts=True)[1].max()
+
         # NNZ is the number of non-zeros per row for the local portion of the matrix
+        t_prev = time.time() 
         NNZ = comm.allreduce(row_lengths, op=MPI.MAX)
-        gmat.setPreallocationNNZ(NNZ)
+        print('Rank ', comm.Get_rank() , ': duration of comm.allreduce :', time.time()-t_prev)
 
+        t_prev = time.time() 
+        gmat.setPreallocationNNZ(NNZ)
+        print('Rank ', comm.Get_rank() , ': duration of setPreallocationNNZ :', time.time()-t_prev)
+
+    t_prev = time.time() 
     # Fill-in matrix values
     for i in range(rows.size):
         # The values have to be set in "addition mode", otherwise the default just takes the new value.
         # This is here necessary, since the COO format can contain repeated entries.
-        gmat.setValues(rows[i], cols[i], data[i], addv=PETSc.InsertMode.ADD_VALUES)
+        gmat.setValues(rows[i], cols[i], data[i])#, addv=PETSc.InsertMode.ADD_VALUES)
 
+    print('Rank ', comm.Get_rank() , ': duration of setValues :', time.time()-t_prev)'''
+  
     # Process inserted matrix entries
     ################################################
     # Note 12.03.2024:
@@ -153,5 +637,8 @@ def mat_topetsc( mat ):
     # In the future we would like that PETSc uses the partition from Psydac, 
     # which might involve passing a DM Object.
     ################################################
+    t_prev = time.time() 
     gmat.assemble()
+    print('Rank ', comm.Get_rank() if comm else '-', ': duration of Mat assembly :', time.time()-t_prev)
+
     return gmat

--- a/psydac/linalg/topetsc.py
+++ b/psydac/linalg/topetsc.py
@@ -8,15 +8,86 @@ from itertools import product as cartesian_prod
 
 from mpi4py import MPI
 
-__all__ = ('flatten_vec', 'vec_topetsc', 'mat_topetsc')
+__all__ = ('petsc_local_to_psydac', 'psydac_to_petsc_global', 'get_npts_local', 'get_npts_per_block', 'vec_topetsc', 'mat_topetsc')
 
 
-def psydac_to_petsc_local(
-     V : VectorSpace,
-     block_indices : tuple[int],
-     ndarray_indices : tuple[int]) -> int :
+def petsc_local_to_psydac(
+    V : VectorSpace,
+    petsc_index : int) -> tuple[tuple[int], tuple[int]]:
     """
-    Convert the Psydac local index to a PETSc local index.
+    Convert the PETSc local index (starting from 0 in each process) to a Psydac local index (natural multi-index, as grid coordinates).
+
+    Parameters
+    -----------
+    V : VectorSpace
+        The vector space to which the Psydac vector belongs.
+        This defines the number of blocks, the size of each block,
+        and how each block is distributed across MPI processes.
+
+    petsc_index : int
+        The local PETSc index. The 0 index is only owned by every process.
+
+    Returns
+    --------
+    block: tuple
+        The block where the Psydac multi-index belongs to.
+    psydac_index : tuple
+        The Psydac local multi-index. This index is local the block.
+    """
+
+    # Get the number of points for each block and each dimension local to the current process:
+    npts_local_per_block = np.array(get_npts_local(V)) # indexed [b,d] for block b and dimension d
+    # Get the local size of the current process for each block:
+    local_sizes_per_block = np.prod(npts_local_per_block, axis=-1)  # indexed [b] for block b
+    # Compute the accumulated local size of the current process for each block:
+    accumulated_local_sizes_per_block = np.concatenate((np.zeros((1,), dtype=int), np.cumsum(local_sizes_per_block, axis=0))) #indexed [b+1] for block b
+
+    n_blocks = local_sizes_per_block.size
+
+    # Find the block where the index belongs to:
+    bb = np.nonzero(
+            np.array(
+                [petsc_index in range(accumulated_local_sizes_per_block[b], accumulated_local_sizes_per_block[b+1]) 
+                    for b in range(n_blocks)]
+            ))[0][0]
+
+    if isinstance(V, BlockVectorSpace):
+        V = V.spaces[bb]
+
+    ndim = V.ndim
+    p = V.pads
+    m = V.shifts    
+
+    # Get the number of points for each dimension local to the current process and block:
+    npts_local = npts_local_per_block[bb]
+    
+    # Get the PETSc index local within the block:
+    petsc_index -= accumulated_local_sizes_per_block[bb]
+    
+    ii = np.zeros((ndim,), dtype=int)
+    if ndim == 1:
+        ii[0] = petsc_index + p[0]*m[0]
+
+    elif ndim == 2:
+        ii[0] = petsc_index // npts_local[1] + p[0]*m[0]
+        ii[1] = petsc_index % npts_local[1] + p[1]*m[1]
+
+    elif ndim == 3:
+        ii[0] = petsc_index // (npts_local[1]*npts_local[2]) + p[0]*m[0]
+        ii[1] = petsc_index // npts_local[2] + p[1]*m[1] - npts_local[1]*(ii[0] - p[0]*m[0])
+        ii[2] = petsc_index % npts_local[2] + p[2]*m[2]
+
+    else:
+        raise NotImplementedError( "Cannot handle more than 3 dimensions." )
+
+    return (bb,), tuple(ii)
+
+def psydac_to_petsc_global(
+        V : VectorSpace, 
+        block_indices : tuple[int], 
+        ndarray_indices : tuple[int]) -> int:
+    """
+    Convert the Psydac local index (natural multi-index, as grid coordinates) to a PETSc global index. Performs a search to find the process owning the multi-index.
 
     Parameters
     -----------
@@ -36,309 +107,63 @@ def psydac_to_petsc_local(
     Returns
     --------
     petsc_index : int
-        The local PETSc index, which is equivalent to the global PETSc index
-        but starts from 0. 
+        The global PETSc index. The 0 index is only owned by the first process.
     """
-
-    ndim = V.ndim
-    starts = V.starts
-    ends = V.ends
-    pads = V.pads
-    shifts = V.shifts
-    shape = V.shape
-
-    ii = ndarray_indices
-
-    npts_local = [ e - s + 1 for s, e in zip(starts, ends)] #Number of points in each dimension within each process. Different for each process.
-    
-    assert all([ii[d] >= pads[d]*shifts[d] and ii[d] < shape[d] - pads[d]*shifts[d] for d in range(ndim)]), 'ndarray_indices within the ghost region'
-
-    if ndim == 1:
-        petsc_index = ii[0] - pads[0]*shifts[0] # global index starting from 0 in each process
-    elif ndim == 2:
-        petsc_index = npts_local[1] * (ii[0] - pads[0]*shifts[0]) + ii[1] - pads[1]*shifts[1] # global index starting from 0 in each process
-    elif ndim == 3:
-        petsc_index = npts_local[1] * npts_local[2] * (ii[0] - pads[0]*shifts[0]) + npts_local[2] * (ii[1] - pads[1]*shifts[1]) + ii[2] - pads[2]*shifts[2]
-    else:
-        raise NotImplementedError( "Cannot handle more than 3 dimensions." )
-    
-    return petsc_index
-
-def get_petsc_local_to_global_shift(V : VectorSpace) -> int:
-    """
-    Compute the correct integer shift (process dependent) in order to convert
-    a PETSc local index to the corresponding global index.
-
-    Parameter
-    ---------
-    V : VectorSpace
-        The distributed Psydac vector space.
-
-    Returns
-    --------
-    int
-        The integer shift which must be added to a local index
-        in order to get a global index.
-    """
-
-    cart = V.cart
-    comm = cart.global_comm
-
-    if comm is None:
-        return 0
-    
-    gstarts = cart.global_starts # Global variable
-    gends = cart.global_ends # Global variable
-
-    npts_local_perprocess = [ ge - gs + 1 for gs, ge in zip(gstarts, gends)] #Global variable
-    npts_local_perprocess = [*cartesian_prod(*npts_local_perprocess)] #Global variable
-    localsize_perprocess = [np.prod(npts_local_perprocess[k]) for k in range(comm.Get_size())] #Global variable
-    index_shift = 0 + np.sum(localsize_perprocess[0:comm.Get_rank()], dtype=int) #Global variable
-
-    return index_shift
-
-def petsc_to_psydac_local(
-    V : VectorSpace,
-    petsc_index : int) :#-> tuple(tuple[int], tuple[int]) :
-    """
-    Convert the PETSc local index to a Psydac local index.
-    This is the inverse of `psydac_to_petsc_local`.
-    """
-
-    npts_local_per_block_per_process = np.array(get_npts_per_block(V)) #indexed [b,k,d] for block b and process k and dimension d
-    local_sizes_per_block_per_process = np.prod(npts_local_per_block_per_process, axis=-1) #indexed [b,k] for block b and process k
-
-    if isinstance(V, BlockVectorSpace):
-        V = V.spaces[bb]
-
-    accumulated_local_sizes_per_block_per_process = np.cumsum(local_sizes_per_block_per_process, axis=0) #indexed [b,k] for block b and process k
-    bb = np.nonzero(np.array([petsc_index in range(accumulated_local_sizes_per_block_per_process[b-1][comm.Get_rank()], accumulated_local_sizes_per_block_per_process[b][comm.Get_rank()])]))[0][0]
-
-
-    ndim = V.ndim
-    starts = V.starts
-    ends = V.ends
-    pads = V.pads
-    shifts = V.shifts    
-
-    npts_local = npts_local_per_block_per_process[bb] #Number of points in each dimension within each process. Different for each process.
-
-    ii = np.zeros((ndim,), dtype=int)
-    if ndim == 1:
-        ii[0] = petsc_index + pads[0]*shifts[0] # global index starting from 0 in each process
-
-    elif ndim == 2:
-        ii[0] = petsc_index // npts_local[1] + pads[0]*shifts[0]
-        ii[1] = petsc_index % npts_local[1] + pads[1]*shifts[1]
-
-    elif ndim == 3:
-        ii[0] = petsc_index // (npts_local[1]*npts_local[2]) + pads[0]*shifts[0]
-        ii[1] = petsc_index // npts_local[2] + pads[1]*shifts[1] - npts_local[1]*(ii[0] - pads[0]*shifts[0])
-        ii[2] = petsc_index % npts_local[2] + pads[2]*shifts[2]
-
-    else:
-        raise NotImplementedError( "Cannot handle more than 3 dimensions." )
-
-    return tuple(tuple(ii))
-
-def global_to_psydac(
-    V : VectorSpace,
-    petsc_index : int) :#-> tuple(tuple[int], tuple[int]) :
-    """
-    Convert the PETSc local index to a Psydac local index.
-    This is the inverse of `psydac_to_petsc_local`.
-    """
-
-    '''npts_local_per_block_per_process = np.array(get_npts_per_block(V)) #indexed [b,k,d] for block b and process k and dimension d
-    local_sizes_per_block_per_process = np.prod(npts_local_per_block_per_process, axis=-1) #indexed [b,k] for block b and process k
-    accumulated_local_sizes_per_block_per_process = np.concatenate((np.zeros_like(local_sizes_per_block_per_process), np.cumsum(local_sizes_per_block_per_process, axis=0))) #indexed [b+1,k] for block b and process k
-    print(f'accumulated_local_sizes_per_block_per_process = {accumulated_local_sizes_per_block_per_process}' )
-    n_blocks = local_sizes_per_block_per_process.shape[0]
-    rk = comm.Get_rank()
-    bb = np.nonzero(
-            np.array(
-                [petsc_index in range(accumulated_local_sizes_per_block_per_process[b][rk], accumulated_local_sizes_per_block_per_process[b+1][rk]) 
-                    for b in range(n_blocks)]
-            ))[0][0]
-    print(f'rk={rk}, bb={bb}')
-    
-    npts_local_per_process = npts_local_per_block_per_process[bb] #indexed [k,d] for process k
-    local_sizes_per_process = np.prod(npts_local_per_process, axis=-1) #indexed [k] for process k
-    accumulated_local_sizes_per_process = np.concatenate((np.zeros((1,), dtype=int), np.cumsum(local_sizes_per_process, axis=0))) #indexed [k+1] for process k
-
-    n_procs = local_sizes_per_process.size
-
-    print(f'n_procs={n_procs}, accumulated_local_sizes_per_process={accumulated_local_sizes_per_process}')    
-    
-    rank = np.nonzero(
-            np.array(
-                [petsc_index in range(accumulated_local_sizes_per_process[k], accumulated_local_sizes_per_process[k+1]) 
-                    for k in range(n_procs)]
-            ))[0][0]
-    
-
-    npts_local = npts_local_per_block_per_process[bb][rank] #Number of points in each dimension within each process. Different for each process.
-    '''
-
-
-    npts_local_per_block = np.array(get_npts_local(V)) #indexed [b,d] for block b and dimension d
-    local_sizes_per_block = np.prod(npts_local_per_block, axis=-1)  #indexed [b] for block b
-    accumulated_local_sizes_per_block = np.concatenate((np.zeros((1,), dtype=int), np.cumsum(local_sizes_per_block, axis=0))) #indexed [b+1] for block b
-
-    n_blocks = local_sizes_per_block.size
-    # Find the block where the index belongs to:
-    bb = np.nonzero(
-            np.array(
-                [petsc_index in range(accumulated_local_sizes_per_block[b], accumulated_local_sizes_per_block[b+1]) 
-                    for b in range(n_blocks)]
-            ))[0][0]
-
-    #print(f'bb={bb}')
-
-    if isinstance(V, BlockVectorSpace):
-        V = V.spaces[bb]
-
-    ndim = V.ndim
-    p = V.pads
-    m = V.shifts    
-
-    npts_local = npts_local_per_block[bb] #Number of points in each dimension within each process. Different for each process.
-    
-    # Get the PETSc index LOCAL in the block:
-    petsc_index -= accumulated_local_sizes_per_block[bb]
-    
-    #npts_local = npts_local_per_block_per_process[bb][rk] 
-    #print(f'npts_local={npts_local}')
-
-    '''# Find shift for process k:
-    npts_local_per_block_per_process = np.array(get_npts_per_block(V)) #indexed [b,k,d] for block b and process k and dimension d
-    local_sizes_per_block_per_process = np.prod(npts_local_per_block_per_process, axis=-1) #indexed [b,k] for block b and process k
-    assert local_sizes_per_block_per_process[:,comm.Get_rank()] == np.prod(npts_local)
-    index_proc_shift = 0 + np.sum(local_sizes_per_block_per_process[bb][0:comm.Get_rank()], dtype=int) #Global variable'''
-
-
-    ii = np.zeros((ndim,), dtype=int)
-    if ndim == 1:
-        ii[0] = petsc_index + p[0]*m[0] # global index starting from 0 in each process
-
-    elif ndim == 2:
-        ii[0] = petsc_index // npts_local[1] + p[0]*m[0]
-        ii[1] = petsc_index % npts_local[1] + p[1]*m[1]
-        #print(f'rank={comm.Get_rank()}, bb={bb}, npts_local={npts_local}, local_petsc_index={petsc_index}, ii={ii}')
-
-    elif ndim == 3:
-        ii[0] = petsc_index // (npts_local[1]*npts_local[2]) + p[0]*m[0]
-        ii[1] = petsc_index // npts_local[2] + p[1]*m[1] - npts_local[1]*(ii[0] - p[0]*m[0])
-        ii[2] = petsc_index % npts_local[2] + p[2]*m[2]
-
-    else:
-        raise NotImplementedError( "Cannot handle more than 3 dimensions." )
-
-    return (bb,), tuple(ii)
-
-def psydac_to_global(V : VectorSpace, block_indices : tuple[int], ndarray_indices : tuple[int]) -> int:
-    '''From Psydac natural multi-index (grid coordinates) to global PETSc single-index.
-    Performs a search to find the process owning the multi-index.'''
-
-    
-    #nonzero_block_indices = ((0,0)) if not isinstance(V, BlockVectorSpace) else V.
-    #s = V.starts
-    #e = V.ends
-    #p = V.pads
-    #m = V.shifts
-    #dnpts = V.cart.npts
-    
-
-    
-    #block_shift = 0
-
-    #for b in bb:
-    '''if isinstance(V, StencilVectorSpace):
-        cart = V.cart
-    elif isinstance(V, BlockVectorSpace):
-        cart = V.spaces[bb[0]].cart'''
-
-    '''# compute the block shift:
-        for b1 in range(min(len(V.spaces), bb[0])):
-            prev_npts_local = 0#np.sum(np.prod([ e - s + 1 for s, e in zip(V.spaces[b1].starts, V.spaces[b1].ends)], axis=1))
-            #for b2 in range(max(0, bb[1])):
-            block_shift += prev_npts_local'''
 
     bb = block_indices[0]
+    # Get the number of points per block, per process and per dimension:
     npts_local_per_block_per_process = np.array(get_npts_per_block(V)) #indexed [b,k,d] for block b and process k and dimension d
+    # Get the local sizes per block and per process:
     local_sizes_per_block_per_process = np.prod(npts_local_per_block_per_process, axis=-1) #indexed [b,k] for block b and process k
-    #print(f'npts_local_per_block_per_process={npts_local_per_block_per_process}')
-    #print(f'local_sizes_per_block_per_process={local_sizes_per_block_per_process}')
 
-    #shift_per_block_per_process = np.sum(local_sizes_per_block_per_process[:][:])
+    # Extract Cartesian decomposition of the Block where the node is:
     if isinstance(V, BlockVectorSpace):
         V = V.spaces[bb]
 
     cart = V.cart
-    #    block_local_shift = get_block_local_shift(V)
-    #    block_shift = block_local_shift[bb[0]]
 
-    nprocs = cart.nprocs
+    nprocs = cart.nprocs # Number of processes in each dimension
     ndim = cart.ndim
+
+    # Get global starts and ends to find process owning the node.
     gs = cart.global_starts # Global variable
     ge = cart.global_ends # Global variable
 
-
-
-    '''#dnpts_local = [ e - s + 1 for s, e in zip(s, e)] #Number of points in each dimension within each process. Different for each process.
-
-    
-
-
-    npts_local_perprocess = [ ge_i - gs_i + 1 for gs_i, ge_i in zip(gs, ge)] #Global variable
-    npts_local_perprocess = [*cartesian_prod(*npts_local_perprocess)] #Global variable
-    localsize_perprocess = [np.prod(npts_local_perprocess[k]) for k in range(cart.comm.Get_size())] #Global variable'''
-
     jj = ndarray_indices
-    if ndim == 1:
-        proc_index = np.nonzero(np.array([jj[0] in range(gs[0][k],ge[0][k]+1) for k in range(gs[0].size)]))[0][0]
-        #index_shift = 0 + np.sum(localsize_perprocess[0:proc_index], dtype=int) #Global variable
 
-        #index_shift = 0 + np.sum(local_sizes_per_block_per_process[bb][0:proc_index], dtype=int) #Global variable
+    if ndim == 1:
+        # Find to which process the node belongs to:
+        proc_index = np.nonzero(np.array([jj[0] in range(gs[0][k],ge[0][k]+1) for k in range(gs[0].size)]))[0][0]
+       
+        # Find the index shift corresponding to the block and the owner process:
         index_shift = 0 + np.sum(local_sizes_per_block_per_process[:,:proc_index]) + np.sum(local_sizes_per_block_per_process[:bb,proc_index])
+
+        # Compute the global PETSc index:
         global_index = index_shift + jj[0] - gs[0][proc_index]
 
     elif ndim == 2:
+        # Find to which process the node belongs to:
         proc_x = np.nonzero(np.array([jj[0] in range(gs[0][k],ge[0][k]+1) for k in range(gs[0].size)]))[0][0]
         proc_y = np.nonzero(np.array([jj[1] in range(gs[1][k],ge[1][k]+1) for k in range(gs[1].size)]))[0][0]
+        proc_index = proc_y + proc_x*nprocs[1]
 
-        proc_index = proc_y + proc_x*nprocs[1]#proc_x + proc_y*nprocs[0]
+        # Find the index shift corresponding to the block and the owner process:
         index_shift = 0 + np.sum(local_sizes_per_block_per_process[:,:proc_index]) + np.sum(local_sizes_per_block_per_process[:bb,proc_index])
-        #index_shift = 0#0 + np.sum(local_sizes_per_block_per_process[bb][0:proc_index], dtype=int) #Global variable
-        #global_index = jj[0] - gs[0][proc_x] + (jj[1] - gs[1][proc_y]) * npts_local_perprocess[proc_index][0] + index_shift 
-        #global_index = index_shift + jj[1] - gs[1][proc_y] + (jj[0] - gs[0][proc_x]) * npts_local_per_block_per_process[bb,proc_index,1]
 
-        #print(f'np.sum(local_sizes_per_block_per_process[:,:proc_index])={np.sum(local_sizes_per_block_per_process[:,:proc_index])}')
-        #print(f'np.sum(local_sizes_per_block_per_process[:bb,proc_index])={np.sum(local_sizes_per_block_per_process[:bb,proc_index])}')
-        #index_shift = 0 + np.sum(local_sizes_per_block_per_process[:,:proc_index]) + np.sum(local_sizes_per_block_per_process[:bb,proc_index])
+        # Compute the global PETSc index:
         global_index = index_shift + jj[1] - gs[1][proc_y] + (jj[0] - gs[0][proc_x]) * npts_local_per_block_per_process[bb,proc_index,1]
-        #print(f'shift={shift}')
-        #x_proc_ranges = np.array([range(gs[0][k],ge[0][k]+1) for k in range(gs[0].size)])
 
-        #hola = np.where(jj[0] in x_proc_ranges)#, gs[0], -1)
-        '''for k in range(V.cart.comm.Get_size()):
-            if k == V.cart.comm.Get_rank():
-                print('\nRank', k, '\njj=', jj)
-                print('proc_x=', proc_x)
-                print('proc_y=', proc_y)
-                print('proc_index=', proc_index)
-                print('index_shift=', index_shift)
-                print('global_index=', global_index)
-                print('npts_local_perprocess=', npts_local_perprocess)
-            V.cart.comm.Barrier()'''
     elif ndim == 3:
+        # Find to which process the node belongs to:
         proc_x = np.nonzero(np.array([jj[0] in range(gs[0][k],ge[0][k]+1) for k in range(gs[0].size)]))[0][0]
         proc_y = np.nonzero(np.array([jj[1] in range(gs[1][k],ge[1][k]+1) for k in range(gs[1].size)]))[0][0]
         proc_z = np.nonzero(np.array([jj[2] in range(gs[2][k],ge[2][k]+1) for k in range(gs[2].size)]))[0][0]
+        proc_index = proc_z + proc_y*nprocs[2] + proc_x*nprocs[1]*nprocs[2]
 
-        proc_index = proc_z + proc_y*nprocs[2] + proc_x*nprocs[1]*nprocs[2] #proc_x + proc_y*nprocs[0]
-        #index_shift = 0 + np.sum(local_sizes_per_block_per_process[bb][0:proc_index], dtype=int) #Global variable
+        # Find the index shift corresponding to the block and the owner process:
         index_shift = 0 + np.sum(local_sizes_per_block_per_process[:,:proc_index]) + np.sum(local_sizes_per_block_per_process[:bb,proc_index])
+
+        # Compute the global PETSc index:
         global_index = index_shift \
                     +  jj[2] - gs[2][proc_z] \
                     + (jj[1] - gs[1][proc_y]) * npts_local_per_block_per_process[bb][proc_index][2] \
@@ -348,40 +173,6 @@ def psydac_to_global(V : VectorSpace, block_indices : tuple[int], ndarray_indice
         raise NotImplementedError( "Cannot handle more than 3 dimensions." )
 
     return global_index 
-
-
-def psydac_to_singlenatural(V : VectorSpace, ndarray_indices : tuple[int]) -> int:
-    ndim = V.ndim
-    dnpts = V.cart.npts
-
-
-    jj = ndarray_indices
-    if ndim == 1:
-        singlenatural_index = 0
-    elif ndim == 2:
-        singlenatural_index = jj[1] + jj[0] * dnpts[1] 
-        
-
-        #x_proc_ranges = np.array([range(gs[0][k],ge[0][k]+1) for k in range(gs[0].size)])
-
-        #hola = np.where(jj[0] in x_proc_ranges)#, gs[0], -1)
-        '''for k in range(V.cart.comm.Get_size()):
-            if k == V.cart.comm.Get_rank():
-                print('\nRank', k, '\njj=', jj)
-                print('proc_x=', proc_x)
-                print('proc_y=', proc_y)
-                print('proc_index=', proc_index)
-                print('index_shift=', index_shift)
-                print('global_index=', global_index)
-                print('npts_local_perprocess=', npts_local_perprocess)
-            V.cart.comm.Barrier()'''
-
-     
-    else:
-        raise NotImplementedError( "Cannot handle more than 3 dimensions." )
-
-
-    return singlenatural_index    
 
 def get_npts_local(V : VectorSpace) -> list:
     """
@@ -412,38 +203,8 @@ def get_npts_local(V : VectorSpace) -> list:
         if isinstance(V.spaces[b], StencilVectorSpace):
             npts_local_b = npts_local_b[0]
         npts_local_per_block.append(npts_local_b)
-    #npts_local_per_block = [ get_npts_local(V.spaces[b]) for b in range(V.n_blocks) ]
+
     return npts_local_per_block
-
-def get_block_local_shift(V : VectorSpace) -> np.ndarray:
-    """
-    Compute the local block shift per block. 
-    This is a local variable, its value will be different for each process.
-
-    Parameter
-    ---------
-    V : VectorSpace
-        The distributed Psydac vector space.
-
-    Returns
-    --------
-    Numpy.ndarray
-        Local block shift per block.
-        In case of a StencilVectorSpace it returns the total local number of points in the space.
-        In case of a BlockVectorSpace the returned array has the same shape as the space block structure.
-    """ 
-    if isinstance(V, StencilVectorSpace):
-        return np.prod(get_npts_local(V))
-    
-    block_local_shift_per_block = []
-    for b in range(V.n_blocks):
-        block_local_shift_per_block.append(get_block_local_shift(V.spaces[b]))
-
-    block_local_shift_per_block = np.array(block_local_shift_per_block)
-
-    block_local_shift_per_block = np.reshape(np.cumsum(block_local_shift_per_block), block_local_shift_per_block.shape)
-
-    return block_local_shift_per_block
 
 def get_npts_per_block(V : VectorSpace) -> list:
 
@@ -454,12 +215,10 @@ def get_npts_per_block(V : VectorSpace) -> list:
         
         if V.cart.comm:
             npts_local_perprocess = [*cartesian_prod(*npts_local_perprocess)] #Global variable
-            #localsize_perprocess = [np.prod(npts_local_perprocess[k]) for k in range(V.cart.comm.Get_size())] #Global variable
-        #else:
-        #    #localsize_perprocess = [np.prod(npts_local_perprocess)]
+
         return [npts_local_perprocess]
 
-    npts_local_per_block = [] #[ get_npts_per_block(V.spaces[b]) for b in range(V.n_blocks) ]
+    npts_local_per_block = [] 
     for b in range(V.n_blocks):
         npts_b = get_npts_per_block(V.spaces[b])
         if isinstance(V.spaces[b], StencilVectorSpace):
@@ -468,127 +227,13 @@ def get_npts_per_block(V : VectorSpace) -> list:
 
     return npts_local_per_block
 
-
-def get_block_shift_per_process(V : VectorSpace) -> list:
-    #shift_per_process = [0]
-    npts_local_per_block = get_npts_per_block(V)
-    local_sizes_per_block = np.prod(npts_local_per_block, axis=-1)
-
-    local_sizes_per_block = np.array(local_sizes_per_block)
-
-    # Get nested block structure:
-    n_blocks = local_sizes_per_block.shape[:-1]
-    # Assume that all the blocks have the same number of processes:
-    n_procs = local_sizes_per_block.shape[-1]
-    print(f'n_procs={n_procs}')
-    local_sizes_per_process = np.array([local_sizes_per_block[:,k] for k in range(n_procs)])
-    print(f'local_sizes_per_process={local_sizes_per_process}')
-
-    #print(f'np.sum(local_sizes_per_process[:k,1:])={np.sum(local_sizes_per_process[:1,1:])}')
-    shift_per_process = [0]+[np.sum(local_sizes_per_process[:k,1:]) for k in range(1,n_procs)]
-
-
-
-    #local_sizes_per_process = np.sum(local_sizes_per_process[1:], axis=1)
-    print(f'shift_per_process={shift_per_process}')
-
-    #shift_per_process = [0] + [ np.sum(local_sizes_per_process[:k-1]) for k in range(1, n_procs)]
-
-
-
-    '''if isinstance(V, StencilVectorSpace):
-        n_procs = 1 if not V.cart.comm else V.cart.comm.Get_size()
-
-        if V.cart.comm:
-            localsize_perprocess = [np.prod(npts_local_per_block[0][k]) for k in range(n_procs)] #Global variable
-        else:
-            localsize_perprocess = [np.prod(npts_local_per_block[k]) for k in range(n_procs)] #Global variable'''
-
-    #for b_lvl in range(len(n_blocks)):
-    #    for b in range(n_blocks[b_lvl]):
-
-    '''for k in range(n_procs):
-        shift_k = 0
-        for b in range(n_blocks[0]):
-            #npts_local_per_process = npts_local_per_block[b]
-            #shift_k += np.prod(npts_local_per_process[k])
-            #if b != len(shift_per_process):
-            shift_k += local_sizes_per_block[b][k]
-        shift_per_process.append(shift_k)'''
-    '''print(f'n_blocks={n_blocks}')
-    for k in range(n_procs):
-        shift_k = 0
-        for b in range(n_blocks[0]):
-            print(f'k={k}, b={b}, local_sizes_per_block={local_sizes_per_block[:,k]}')
-            #accumulated_local_size = local_sizes_per_block[:b]#[k]
-            
-            if b == 1:
-                accumulated_local_size = local_sizes_per_block[0][k]
-            else:
-                accumulated_local_size = local_sizes_per_block[b][k]
-            shift_k += np.sum(accumulated_local_size)
-        shift_per_process.append(shift_k)'''
-    
-    return shift_per_process
-
-
-
-def flatten_vec( vec ):
-    """ Return the flattened 1D array values and indices owned by the process of the given vector.
-
-    Parameters
-    ----------
-    vec : psydac.linalg.stencil.StencilVector | psydac.linalg.block.BlockVector
-      Psydac vector to be flattened
-
-    Returns
-    -------
-    indices: numpy.ndarray
-        The global indices of the data array collapsed into one dimension.
-
-    array : numpy.ndarray
-        A copy of the data array collapsed into one dimension.
-
-    """
-
-    if isinstance(vec, StencilVector):
-        npts = vec.space.npts
-        idx = tuple( slice(m*p,-m*p) for m,p in zip(vec.pads, vec.space.shifts) )
-        shape = vec._data[idx].shape
-        starts = vec.space.starts
-        indices = np.array([np.ravel_multi_index( [s+x for s,x in zip(starts, xx)], dims=npts,  order='C' ) for xx in np.ndindex(*shape)] )
-        data = vec._data[idx].flatten()
-        vec = coo_matrix(
-                    (data,(indices,indices)),
-                    shape = [vec.space.dimension,vec.space.dimension],
-                    dtype = vec.space.dtype)
-
-    elif isinstance(vec, BlockVector):
-        vecs = [flatten_vec(b) for b in vec.blocks]
-        vecs = [coo_matrix((v[1],(v[0],v[0])),
-                shape=[vs.space.dimension,vs.space.dimension],
-                dtype=vs.space.dtype) for v,vs in zip(vecs, vec.blocks)]
-
-        blocks = [[None]*len(vecs) for v in vecs]
-        for i,v in enumerate(vecs):
-            blocks[i][i] = v
-
-        vec = bmat(blocks,format='coo')
-
-    else:
-        raise TypeError("Expected StencilVector or BlockVector, found instead {}".format(type(vec)))
-
-    array   = vec.data
-    indices = vec.row
-    return indices, array
-
 def vec_topetsc( vec ):
     """ Convert vector from Psydac format to a PETSc.Vec object.
 
     Parameters
     ----------
     vec : psydac.linalg.stencil.StencilVector | psydac.linalg.block.BlockVector
-      Psydac StencilVector or BlockVector.
+      Psydac StencilVector or BlockVector. In the case of a BlockVector, only the case where the blocks are StencilVector is implemented.
 
     Returns
     -------
@@ -598,39 +243,31 @@ def vec_topetsc( vec ):
     from petsc4py import PETSc
 
     if isinstance(vec.space, BlockVectorSpace) and any([isinstance(vec.space.spaces[b], BlockVectorSpace) for b in range(len(vec.space.spaces))]):
-        raise NotImplementedError('Block of blocks not implemented.')
+        raise NotImplementedError('Conversion for block of blocks not implemented.')
 
     if isinstance(vec, StencilVector):
         carts = [vec.space.cart]
     elif isinstance(vec.space, BlockVectorSpace):
         carts = []
         for b in range(vec.n_blocks):
-            if isinstance(vec.space.spaces[b], StencilVectorSpace):
-                carts.append(vec.space.spaces[b].cart)
+            carts.append(vec.space.spaces[b].cart)
 
-            elif isinstance(vec.space.spaces[b], BlockVectorSpace):
-                carts2 = []
-                for b2 in range(vec.space.spaces[b].n_blocks):
-                    if isinstance(vec.space.spaces[b][b2], StencilVectorSpace):
-                        carts2.append(vec.space.spaces[b][b2].cart)
-                    else:
-                        raise NotImplementedError( "Cannot handle more than block of a block." )
-                carts.append(carts2)
+    n_blocks = 1 if isinstance(vec, StencilVector) else vec.n_blocks
 
+    # Get the number of points local to the current process:
+    npts_local = get_npts_local(vec.space) # indexed [block, dimension]. Different for each process.
 
-
-
-    npts_local = get_npts_local(vec.space) #[[ e - s + 1 for s, e in zip(cart.starts, cart.ends)] for cart in carts] #Number of points in each dimension within each process. Different for each process.
-
-    comms = [cart.global_comm for cart in carts]
-
+    # Number of dimensions for each cart:
     ndims = [cart.ndim for cart in carts]
 
-
-    gvec  = PETSc.Vec().create(comm=comms[0])
-
     globalsize = vec.space.dimension
-    localsize = np.sum(np.prod(npts_local, axis=1)) # Sum over all the blocks
+
+    # Sum over the blocks to get the total local size
+    localsize = np.sum(np.prod(npts_local, axis=1))
+
+    gvec  = PETSc.Vec().create(comm=carts[0].global_comm)    
+
+    # Set global and local size:
     gvec.setSizes(size=(localsize, globalsize))
 
     gvec.setFromOptions()
@@ -639,35 +276,32 @@ def vec_topetsc( vec ):
     petsc_indices = []
     petsc_data = []
 
-    s = [cart.starts for cart in carts]
-    ghost_size = [[pi*mi for pi,mi in zip(cart.pads, cart.shifts)] for cart in carts]
-
-    n_blocks = 1 if isinstance(vec, StencilVector) else vec.n_blocks
-
     vec_block = vec
 
     for b in range(n_blocks): 
         if isinstance(vec, BlockVector):
             vec_block = vec.blocks[b]
+        
+        s = carts[b].starts
+        ghost_size = [pi*mi for pi,mi in zip(carts[b].pads, carts[b].shifts)]
 
         if ndims[b] == 1:
             for i1 in range(npts_local[b][0]):
-                value = vec_block._data[i1 + ghost_size[b][0]]
+                value = vec_block._data[i1 + ghost_size[0]]
                 if value != 0:
-                    i1_n = s[b][0] + i1
-                    i_g = psydac_to_global(vec.space, (b,), (i1_n,))
+                    i1_n = s[0] + i1
+                    i_g = psydac_to_petsc_global(vec.space, (b,), (i1_n,))
                     petsc_indices.append(i_g)
                     petsc_data.append(value)        
 
         elif ndims[b] == 2:
             for i1 in range(npts_local[b][0]):
                 for i2 in range(npts_local[b][1]):
-                    value = vec_block._data[i1 + ghost_size[b][0], i2 + ghost_size[b][1]]
+                    value = vec_block._data[i1 + ghost_size[0], i2 + ghost_size[1]]
                     if value != 0:
-                        i1_n = s[b][0] + i1
-                        i2_n = s[b][1] + i2                    
-                        i_g = psydac_to_global(vec.space, (b,), (i1_n, i2_n)) 
-                        #print(f'Rank {comms[b].Get_rank()}, Block {b}: i1_n = {i1_n}, i2_n = {i2_n}, i_g = {i_g}')
+                        i1_n = s[0] + i1
+                        i2_n = s[1] + i2                    
+                        i_g = psydac_to_petsc_global(vec.space, (b,), (i1_n, i2_n))
                         petsc_indices.append(i_g)
                         petsc_data.append(value)
 
@@ -675,37 +309,30 @@ def vec_topetsc( vec ):
             for i1 in np.arange(npts_local[b][0]):             
                 for i2 in np.arange(npts_local[b][1]):
                     for i3 in np.arange(npts_local[b][2]):
-                        value = vec_block._data[i1 + ghost_size[b][0], i2 + ghost_size[b][1], i3 + ghost_size[b][2]]
+                        value = vec_block._data[i1 + ghost_size[0], i2 + ghost_size[1], i3 + ghost_size[2]]
                         if value != 0:
-                            i1_n = s[b][0] + i1
-                            i2_n = s[b][1] + i2
-                            i3_n = s[b][2] + i3    
-                            i_g = psydac_to_global(vec.space, (b,), (i1_n, i2_n, i3_n))                    
+                            i1_n = s[0] + i1
+                            i2_n = s[1] + i2
+                            i3_n = s[2] + i3    
+                            i_g = psydac_to_petsc_global(vec.space, (b,), (i1_n, i2_n, i3_n))                    
                             petsc_indices.append(i_g)
                             petsc_data.append(value)        
 
+    # Set the values. The values are stored in a cache memory.
+    gvec.setValues(petsc_indices, petsc_data, addv=PETSc.InsertMode.ADD_VALUES) #The addition mode the values is necessary when periodic BC
 
-    gvec.setValues(petsc_indices, petsc_data, addv=PETSc.InsertMode.ADD_VALUES) #Adding the values is necessary when periodic BC
-
-    # Assemble vector
-    gvec.assemble() # Here PETSc exchanges global communication. The block corresponding to a certain process is not necessarily the same block in the Psydac StencilVector.
-
-    vec_arr = vec.toarray()
-    for k in range(comms[0].Get_size()):
-        if k == comms[0].Get_rank():
-            print(f'Rank {k}: vec={vec_arr}, petsc_indices={petsc_indices}, data={petsc_data}, s={s}, npts_local={npts_local}, gvec={gvec.array.real}')
-        comms[0].Barrier()    
+    # Assemble vector with the values from the cache. Here it is where PETSc exchanges global communication.
+    gvec.assemble()
 
     return gvec
-
 
 def mat_topetsc( mat ):
     """ Convert operator from Psydac format to a PETSc.Mat object.
 
     Parameters
     ----------
-    mat : psydac.linalg.stencil.StencilMatrix | psydac.linalg.basic.LinearOperator | psydac.linalg.block.BlockLinearOperator
-      Psydac operator
+    mat : psydac.linalg.stencil.StencilMatrix | psydac.linalg.block.BlockLinearOperator
+      Psydac operator. In the case of a BlockLinearOperator, only the case where the blocks are StencilMatrix is implemented.
 
     Returns
     -------
@@ -715,24 +342,14 @@ def mat_topetsc( mat ):
 
     from petsc4py import PETSc
 
+    assert isinstance(mat, StencilMatrix) or isinstance(mat, BlockLinearOperator), 'Conversion only implemented for StencilMatrix and BlockLinearOperator.'
+
+
     if (isinstance(mat.domain, BlockVectorSpace) and any([isinstance(mat.domain.spaces[b], BlockVectorSpace) for b in range(len(mat.domain.spaces))]))\
         or (isinstance(mat.codomain, BlockVectorSpace) and any([isinstance(mat.codomain.spaces[b], BlockVectorSpace) for b in range(len(mat.codomain.spaces))])):
-        raise NotImplementedError('Block of blocks not implemented.')
+        raise NotImplementedError('Conversion for block of blocks not implemented.')
 
-    '''if isinstance(mat, StencilMatrix):
-        dcart = mat.domain.cart
-        ccart = mat.codomain.cart
-    elif isinstance(mat.domain.spaces[0], StencilVectorSpace):
-        dcart = mat.domain.spaces[0].cart
-    elif isinstance(mat.domain.spaces[0], BlockVectorSpace):
-        dcart = mat.domain.spaces[0][0].cart
 
-    if isinstance(mat._codomain, StencilVectorSpace):
-        ccart = mat.codomain.cart
-    elif isinstance(mat.codomain.spaces[0], StencilVectorSpace):
-        ccart = mat.codomain.spaces[0].cart
-    elif isinstance(mat.codomain.spaces[0], BlockVectorSpace):
-        ccart = mat.codomain.spaces[0][0].cart  '''      
 
     if isinstance(mat.domain, StencilVectorSpace):
         dcarts = [mat.domain.cart]
@@ -748,130 +365,47 @@ def mat_topetsc( mat ):
         for b in range(len(mat.codomain.spaces)):
                 ccarts.append(mat.codomain.spaces[b].cart)
 
-    n_blocks = (len(ccarts), len(dcarts))
     nonzero_block_indices = ((0,0),) if isinstance(mat, StencilMatrix) else mat.nonzero_block_indices
-
-
-    '''if isinstance(mat, StencilMatrix):
-        dcarts = [mat.domain.cart]
-        ccarts = [mat.codomain.cart]
-        nonzero_block_indices = ((0,0),) 
-        n_blocks = (1,1)
-    elif isinstance(mat, BlockLinearOperator):
-        dcarts = []
-        ccarts = []
-        for b in range(len(mat.domain.spaces)):
-                dcarts.append(mat.domain.spaces[b].cart)
-        for b in range(len(mat.codomain.spaces)):
-                ccarts.append(mat.codomain.spaces[b].cart)     
-
-        nonzero_block_indices = mat.nonzero_block_indices
-        n_blocks = (len(dcarts), len(ccarts))       '''            
-
-
-
-    dcomms = [dcart.global_comm for dcart in dcarts]
-    dcomm = dcomms[0]
-    #ccomms = [ccart.global_comm for ccart in ccarts]
 
     mat.update_ghost_regions()
     mat.remove_spurious_entries()
 
+    # Number of dimensions for each cart:
     dndims = [dcart.ndim for dcart in dcarts]
     cndims = [ccart.ndim for ccart in ccarts]
-    dnpts =  [dcart.npts for dcart in dcarts]    
-    cnpts =  [ccart.npts for ccart in ccarts] 
+    # Get global number of points per block:
+    dnpts =  [dcart.npts for dcart in dcarts] # indexed [block, dimension]. Same for all processes.   
+
+    # Get the number of points local to the current process:
+    dnpts_local = get_npts_local(mat.domain) # indexed [block, dimension]. Different for each process.
+    cnpts_local = get_npts_local(mat.codomain) # indexed [block, dimension]. Different for each process. 
+
+    globalsize = mat.shape
+
+    # Sum over the blocks to get the total local size
+    localsize = (np.sum(np.prod(cnpts_local, axis=1)), np.sum(np.prod(dnpts_local, axis=1)))
+
+    gmat  = PETSc.Mat().create(comm=dcarts[0].global_comm)
+
+    # Set global and local sizes: size=((local_rows, rows), (local_columns, columns))
+    gmat.setSizes(size=((localsize[0], globalsize[0]), (localsize[1], globalsize[1])))
     
-    '''
-    dstarts = dcart.starts
-    dends = dcart.ends
-    dpads = dcart.pads
-    dshifts = dcart.shifts
-
-
-    cndim = ccart.ndim
-    cstarts = ccart.starts
-    cends = ccart.ends
-    #cpads = ccart.pads
-    #cshifts = ccart.shifts
-    cnpts = ccart.npts '''
-
-    dnpts_local = get_npts_local(mat.domain) #[ e - s + 1 for s, e in zip(dstarts, dends)] #Number of points in each dimension within each process. Different for each process.
-    cnpts_local = get_npts_local(mat.codomain) #[ e - s + 1 for s, e in zip(cstarts, cends)]
-
-
-
-    '''mat_dense = mat.tosparse().todense()
-    for k in range(dcomm.Get_size()):
-        if k == dcomm.Get_rank():
-            print('\nRank ', k)
-            print('dstarts=', dstarts)
-            print('dends=', dends)
-            print('cstarts=', cstarts)
-            print('cends=', cends)
-            print('dnpts=', dnpts)            
-            print('cnpts=', cnpts)
-            print('dnpts_local=', dnpts_local)
-            print('cnpts_local=', cnpts_local)
-            #print('mat_dense=\n', mat_dense[:3])
-            #print('mat._data.shape=\n', mat._data.shape)
-            #print('dindex_shift=', dindex_shift)
-            #print('cindex_shift=', cindex_shift)
-            print('ccart.global_starts=', ccart.global_starts)
-            print('ccart.global_ends=', ccart.global_ends)
-            #print('mat._data=\n', mat._data)
-
-        dcomm.Barrier() 
-        ccomm.Barrier() '''
-
-
-    globalsize = mat.shape #equivalent to (np.prod(dnpts), np.prod(cnpts)) #Tuple of integers
-    localsize = (np.sum(np.prod(cnpts_local, axis=1)), np.sum(np.prod(dnpts_local, axis=1))) #(np.prod(cnpts_local)*n_block_rows, np.prod(dnpts_local)*n_block_cols)
-
-    gmat  = PETSc.Mat().create(comm=dcomm)
-
-    gmat.setSizes(size=((localsize[0], globalsize[0]), (localsize[1], globalsize[1]))) #((local_rows, rows), (local_columns, columns))
-    
-    if dcomm:
+    if dcarts[0].global_comm:
         # Set PETSc sparse parallel matrix type
         gmat.setType("mpiaij")
     else:
+        # Set PETSc sparse sequential matrix type
         gmat.setType("seqaij")
 
     gmat.setFromOptions()
     gmat.setUp()
 
-    print('gmat.getSizes()=', gmat.getSizes())
-
-    '''mat_coo = mat.tosparse()
-    rows_coo, cols_coo, data_coo = mat_coo.row, mat_coo.col, mat_coo.data
-
-    mat_csr = mat_coo.tocsr()
-    mat_csr.eliminate_zeros()
-    data, indices, indptr = mat_csr.data, mat_csr.indices, mat_csr.indptr
-    #indptr_chunk = indptr[indptr >= dcart.starts[0] and indptr <= dcart.ends[0]]
-    #indices_chunk = indices[indices >= dcart.starts[1] and indices <= dcart.ends[1]]
-
-    mat_coo_local = mat.tocoo_local()
-    rows_coo_local, cols_coo_local, data_coo_local = mat_coo_local.row, mat_coo_local.col, mat_coo_local.data'''
-
-
-    #mat.remove_spurious_entries()
-
-    I = [0]
-    J = []
-    V = []
-    #J2 = []
-    rowmap = []
-    #rowmap2 = []
-
-    #s = [dcart.starts for dcart in dcarts]
-    #p = [dcart.pads for dcart in dcarts]
-    #m = [dcart.shifts for dcart in dcarts]
-    ghost_size = [[pi*mi for pi,mi in zip(dcart.pads, dcart.shifts)] for dcart in dcarts]
+    I = [0] # Row pointers
+    J = [] # Column indices
+    V = [] # Values
+    rowmap = [] # Row indices of rows containing non-zeros
 
     mat_block = mat
-
 
     for bc, bd in nonzero_block_indices:
         if isinstance(mat, BlockLinearOperator):
@@ -883,24 +417,19 @@ def mat_topetsc( mat ):
         ghost_size = [pi*mi for pi,mi in zip(p, m)]
 
         if dndims[bd] == 1 and cndims[bc] == 1:
-        
-            #if isinstance(mat, StencilMatrix):
-            #    data = mat._data
-            #elif isinstance(mat, BlockLinearOperator):
-            #    data = mat.blocks[bb[0]][bb[1]]._data
 
             for i1 in range(dnpts_local[bd][0]):
                 nnz_in_row = 0
                 i1_n = s[0] + i1
-                i_g = psydac_to_global(mat.codomain, (bc,), (i1_n,))
+                i_g = psydac_to_petsc_global(mat.codomain, (bc,), (i1_n,))
 
                 for k1 in range(-p[0]*m[0], p[0]*m[0] + 1):
                     value = mat_block._data[i1 + ghost_size[0], (k1 + ghost_size[0])%(2*p[0]*m[0] + 1)]
-                    j1_n = (i1_n + k1)%dnpts[bd][0] 
+
+                    j1_n = (i1_n + k1) % dnpts[bd][0] # modulus is necessary for periodic BC
                     
                     if value != 0:
-
-                        j_g = psydac_to_global(mat.domain, (bd,), (j1_n, ))
+                        j_g = psydac_to_petsc_global(mat.domain, (bd,), (j1_n, ))
 
                         if nnz_in_row == 0:
                             rowmap.append(i_g)  
@@ -913,39 +442,29 @@ def mat_topetsc( mat ):
                 I.append(I[-1] + nnz_in_row)
                 
         elif dndims[bd] == 2 and cndims[bc] == 2:
-            for i1 in np.arange(dnpts_local[bd][0]):#dindices[0]:  #range(dpads[0]*dshifts[0] + dnpts_local[0]):               
-                for i2 in np.arange(dnpts_local[bd][1]):#dindices[1]: #range(dpads[1]*dshifts[1] + dnpts_local[1]): 
+            for i1 in np.arange(dnpts_local[bd][0]):              
+                for i2 in np.arange(dnpts_local[bd][1]):
 
                     nnz_in_row = 0
 
                     i1_n = s[0] + i1
                     i2_n = s[1] + i2
-                    i_g = psydac_to_global(mat.codomain, (bc,), (i1_n, i2_n))
-                    #i_n = psydac_to_singlenatural(mat.codomain, (i1_n,i2_n))
-
-                    '''for k in range(dcomm.Get_size()):
-                        if k == dcomm.Get_rank():
-                            print(f'Rank {k}: ({i1_n}, {i2_n}), i_n= {i_n}, i_g= {i_g}')'''
+                    i_g = psydac_to_petsc_global(mat.codomain, (bc,), (i1_n, i2_n))
 
                     for k1 in range(- p[0]*m[0], p[0]*m[0] + 1):                    
                         for k2 in range(- p[1]*m[1], p[1]*m[1] + 1):
-
                             value = mat_block._data[i1 + ghost_size[0], i2 + ghost_size[1], (k1 + ghost_size[0])%(2*p[0]*m[0] + 1), (k2 + ghost_size[1])%(2*p[1]*m[1] + 1)]
 
-                            #(j1_n, j2_n) is the Psydac natural multi-index (like a grid)
-                            j1_n = (i1_n + k1)%dnpts[bd][0] #- p[0]*m[0]
-                            j2_n = (i2_n + k2)%dnpts[bd][1] #- p[1]*m[1]
+                            j1_n = (i1_n + k1) % dnpts[bd][0] # modulus is necessary for periodic BC
+                            j2_n = (i2_n + k2) % dnpts[bd][1] # modulus is necessary for periodic BC
 
-                            if value != 0: #and j1_n in range(dnpts[0]) and j2_n in range(dnpts[1]):
-                                j_g = psydac_to_global(mat.domain, (bd,), (j1_n, j2_n))
+                            if value != 0:
+                                j_g = psydac_to_petsc_global(mat.domain, (bd,), (j1_n, j2_n))
 
                                 if nnz_in_row == 0:
                                     rowmap.append(i_g)     
-                                    #rowmap2.append(psydac_to_singlenatural(mat.domain, (i1_n,i2_n)))                 
 
                                 J.append(j_g)
-                                #J2.append(psydac_to_singlenatural(mat.domain, (j1_n,j2_n)))
-
                                 V.append(value)  
 
                                 nnz_in_row += 1
@@ -960,376 +479,34 @@ def mat_topetsc( mat ):
                         i1_n = s[0] + i1
                         i2_n = s[1] + i2
                         i3_n = s[2] + i3
-                        i_g = psydac_to_global(mat.codomain, (bc,), (i1_n, i2_n, i3_n))
+                        i_g = psydac_to_petsc_global(mat.codomain, (bc,), (i1_n, i2_n, i3_n))
 
                         for k1 in range(-p[0]*m[0], p[0]*m[0] + 1):                    
                             for k2 in range(-p[1]*m[1], p[1]*m[1] + 1):
                                 for k3 in range(-p[2]*m[2], p[2]*m[2] + 1):
                                     value = mat_block._data[i1 + ghost_size[0], i2 + ghost_size[1], i3 + ghost_size[2], (k1 + ghost_size[0])%(2*p[0]*m[0] + 1), (k2 + ghost_size[1])%(2*p[1]*m[1] + 1), (k3 + ghost_size[2])%(2*p[2]*m[2] + 1)]
 
-                                    j1_n = (i1_n + k1)%dnpts[bd][0] #- ghost_size[0]
-                                    j2_n = (i2_n + k2)%dnpts[bd][1] # - ghost_size[1]
-                                    j3_n = (i3_n + k3)%dnpts[bd][2] # - ghost_size[2]
+                                    j1_n = (i1_n + k1)%dnpts[bd][0] # modulus is necessary for periodic BC
+                                    j2_n = (i2_n + k2)%dnpts[bd][1] # modulus is necessary for periodic BC
+                                    j3_n = (i3_n + k3)%dnpts[bd][2] # modulus is necessary for periodic BC
 
-                                    if value != 0: #and j1_n in range(dnpts[0]) and j2_n in range(dnpts[1]) and j3_n in range(dnpts[2]):
-                                        j_g = psydac_to_global(mat.domain, (bd,), (j1_n, j2_n, j3_n))
+                                    if value != 0:
+                                        j_g = psydac_to_petsc_global(mat.domain, (bd,), (j1_n, j2_n, j3_n))
 
                                         if nnz_in_row == 0: 
                                             rowmap.append(i_g)     
                                 
                                         J.append(j_g)
                                         V.append(value)  
+
                                         nnz_in_row += 1
 
                         I.append(I[-1] + nnz_in_row)
 
-
-
-
-    if not dcomm:
-        print()
-        #print('mat_dense=', mat_dense)
-        #print('gmat_dense=', gmat_dense)
-    else:
-        for k in range(dcomm.Get_size()):
-            if k == dcomm.Get_rank():
-                print('\n\nRank ', k)
-                #print('mat_dense=\n', mat_dense)
-                #print('petsc_row_indices=\n', petsc_row_indices)
-                #print('petsc_col_indices=\n', petsc_col_indices)
-                #print('petsc_data=\n', petsc_data)
-                #print('owned_rows=', owned_rows)
-                #print('mat_dense=\n', mat_dense)
-                print('I=', I)
-                print('rowmap=', rowmap)
-                #print('rowmap2=', rowmap2)
-                print('J=\n', J)
-                #print('J2=\n', J2)
-                #print('V=\n', V)
-                #print('gmat_dense=\n', gmat_dense)     
-                print('\n\n============')   
-            dcomm.Barrier()  
-    
-    import time
-    t_prev = time.time() 
-    '''for k in range(len(rows_coo)):
-        gmat.setValues(rows_coo[k] - dcart.global_starts[0][comm.Get_rank()], cols_coo[k], data_coo[k])
-    '''
-    #gmat.setValuesCSR([r - dcart.global_starts[0][comm.Get_rank()] for r in indptr[1:]], indices, data)
-    #gmat.setValuesLocalCSR(local_indptr, indices, data)#, addv=PETSc.InsertMode.ADD_VALUES)
+    # Set the values using IJV&rowmap format. The values are stored in a cache memory.
     gmat.setValuesIJV(I, J, V, rowmap=rowmap, addv=PETSc.InsertMode.ADD_VALUES) # The addition mode is necessary when periodic BC
 
-
-    print('Rank ', dcomm.Get_rank() if dcomm else '-', ': duration of setValuesIJV :', time.time()-t_prev)
-  
-
-  
-    # Process inserted matrix entries
-    ################################################
-    # Note 12.03.2024:
-    # In the assembly PETSc uses global communication to distribute the matrix in a different way than Psydac.
-    # For this reason, at the moment we cannot compare directly each distributed 'chunck' of the Psydac and the PETSc matrices.
-    # In the future we would like that PETSc uses the partition from Psydac, 
-    # which might involve passing a DM Object.
-    ################################################
-    t_prev = time.time() 
+    # Assemble the matrix with the values from the cache. Here it is where PETSc exchanges global communication.
     gmat.assemble()
-    print('Rank ', dcomm.Get_rank() if dcomm else '-', ': duration of Mat assembly :', time.time()-t_prev)
-
-    
-    '''
-    if not dcomm:
-        gmat_dense = gmat.getDenseArray()
-    else:   
-        gmat_dense = gmat.getDenseLocalMatrix()
-        dcomm.Barrier()
-    '''
       
-    return gmat
-
-
-def mat_topetsc_old( mat ):
-    """ Convert operator from Psydac format to a PETSc.Mat object.
-
-    Parameters
-    ----------
-    mat : psydac.linalg.stencil.StencilMatrix | psydac.linalg.basic.LinearOperator | psydac.linalg.block.BlockLinearOperator
-      Psydac operator
-
-    Returns
-    -------
-    gmat : PETSc.Mat
-        PETSc Matrix
-    """
-
-    from petsc4py import PETSc
-
-    if isinstance(mat, StencilMatrix):
-        dcart = mat.domain.cart
-        ccart = mat.codomain.cart
-    elif isinstance(mat.domain.spaces[0], StencilVectorSpace):
-        dcart = mat.domain.spaces[0].cart
-        ccart = mat.codomain.spaces[0].cart
-    elif isinstance(mat.domain.spaces[0], BlockVectorSpace):
-        dcart = mat.domain.spaces[0][0].cart
-        ccart = mat.codomain.spaces[0][0].cart
-
-    comm = dcart.global_comm
-
-
-    #print('mat.shape = ', mat.shape)
-    #print('rank: ', comm.Get_rank(), ', local_ncells=', dcart.domain_decomposition.local_ncells)
-    #print('rank: ', comm.Get_rank(), ', nprocs=', dcart.domain_decomposition.nprocs)
-
-
-    #recvbuf = np.empty(shape=(dcart.domain_decomposition.nprocs[0],1))
-    #comm.allgather(sendbuf=dcart.domain_decomposition.local_ncells, recvbuf=recvbuf)
-    
-    ####################################
-    
-    ### SPLITTING DOMAIN
-    #ownership_ranges = [comm.allgather(dcart.domain_decomposition.local_ncells[k]) for k in range(dcart.ndim)]
-    
-    '''boundary_type = [(PETSc.DM.BoundaryType.PERIODIC if mat.domain.periods[k] else PETSc.DM.BoundaryType.NONE) for k in range(dcart.ndim)]
-
-
-    dim = dcart.ndim
-    sizes = dcart.npts
-    proc_sizes = dcart.nprocs
-    #ownership_ranges = [[ 1 + dcart.global_ends[p][k] - dcart.global_starts[p][k] 
-    #                                                    for k in range(dcart.global_starts[p].size)] 
-    #                                                        for p in range(len(dcart.global_starts))]
-    ownership_ranges = [[e - s + 1 for s,e in zip(starts, ends)] for starts, ends in zip(dcart.global_starts, dcart.global_ends)]
-    print('OWNership_ranges=', ownership_ranges)
-    Dmda = PETSc.DMDA().create(dim=dim, sizes=sizes, proc_sizes=proc_sizes, 
-                               ownership_ranges=ownership_ranges, comm=comm, 
-                               stencil_type=PETSc.DMDA.StencilType.BOX, boundary_type=boundary_type)'''
-    
-
-    '''### SPLITTING COEFFS
-    ownership_ranges = [[ 1 + dcart.global_ends[p][k] - dcart.global_starts[p][k] for k in range(dcart.global_starts[p].size)] for p in range(len(dcart.global_starts))]
-    #ownership_ranges = [comm.allgather(dcart.domain_decomposition.local_ncells[k]) for k in range(dcart.ndim)]
-    
-    print('MAT: ownership_ranges=', ownership_ranges)
-    print('MAT: dcart.domain_decomposition.nprocs=', *dcart.domain_decomposition.nprocs)
-
-    boundary_type = [(PETSc.DM.BoundaryType.PERIODIC if mat.domain.periods[k] else PETSc.DM.BoundaryType.NONE) for k in range(dcart.ndim)]
-
-    Dmda = PETSc.DMDA().create(dim=1, sizes=mat.shape, proc_sizes=[*dcart.domain_decomposition.nprocs,1], comm=comm, 
-                               ownership_ranges=[ownership_ranges[0], [mat.shape[1]]], stencil_type=PETSc.DMDA.StencilType.BOX, boundary_type=boundary_type)
-    '''
-
-    '''    if comm:
-        dcart_petsc = dcart.topetsc()
-        d_LG_map    = dcart_petsc.l2g_mapping
-
-        ccart_petsc = ccart.topetsc()
-        c_LG_map    = ccart_petsc.l2g_mapping
-
-        print('Rank', comm.Get_rank(), ': dcart_petsc.local_size = ', dcart_petsc.local_size)
-        print('Rank', comm.Get_rank(), ': dcart_petsc.local_shape = ', dcart_petsc.local_shape)
-        print('Rank', comm.Get_rank(), ': ccart_petsc.local_size = ', ccart_petsc.local_size)
-        print('Rank', comm.Get_rank(), ': ccart_petsc.local_shape = ', ccart_petsc.local_shape)
-
-    if not comm:
-        print('')
-    else:
-        for k in range(comm.Get_size()):
-            if comm.Get_rank() == k:
-                print('\nRank ', k)
-                print('mat=\n', mat.tosparse().toarray())
-                print('dcart.local_ncells=', dcart.domain_decomposition.local_ncells)
-                print('ccart.local_ncells=', ccart.domain_decomposition.local_ncells)
-                print('dcart._grids=', dcart._grids)
-                print('ccart._grids=', ccart._grids)
-                print('dcart.starts =', dcart.starts)
-                print('dcart.ends =', dcart.ends)
-                print('ccart.starts =', ccart.starts)
-                print('ccart.ends =', ccart.ends)
-                print('dcart.shape=', dcart.shape)
-                print('dcart.npts=', dcart.npts)
-                print('ccart.shape=', ccart.shape)
-                print('ccart.npts=', ccart.npts)
-                print('\ndcart.indices=', dcart_petsc.indices)
-                print('ccart.indices=', ccart_petsc.indices)
-                print('dcart.global_starts=', dcart.global_starts)
-                print('dcart.global_ends=', dcart.global_ends)
-                print('ccart.global_starts=', ccart.global_starts)
-                print('ccart.global_ends=', ccart.global_ends)
-            comm.Barrier()
-    '''
-
-    print('Dmda.getOwnershipRanges()=', Dmda.getOwnershipRanges())
-    print('Dmda.getRanges()=', Dmda.getRanges())
-
-    #LGmap = PETSc.LGMap().create(indices=)
-
-    #dm = PETSc.DM().create(comm=comm)
-    gmat  = PETSc.Mat().create(comm=comm)
-
-    gmat.setDM(Dmda)
-    # Set GLOBAL matrix size
-    #gmat.setSizes(mat.shape)
-
-    #gmat.setSizes(size=((dcart.domain_decomposition.local_ncells[0],mat.shape[0]), (mat.shape[1],mat.shape[1])),
-    #              bsize=None)
-    #gmat.setSizes([[dcart_petsc.local_size, mat.shape[0]], [ccart_petsc.local_size, mat.shape[1]]])      #mat.setSizes([[nrl, nrg], [ncl, ncg]])
-    
-    local_rows = np.prod([e - s + 1 for s, e in zip(ccart.starts, ccart.ends)])
-    #local_columns = np.prod([p*m for p, m in zip(mat.domain.pads, mat.domain.shifts)])
-    local_columns = np.prod([e - s + 1 for s, e in zip(dcart.starts, dcart.ends)])    
-    rows = mat.shape[0]
-    columns = mat.shape[1]
-    gmat.setSizes(size=((local_rows, rows), (local_columns, columns))) #((local_rows, rows), (local_columns, columns))
-    
-    if comm:
-        # Set PETSc sparse parallel matrix type
-        gmat.setType("mpiaij")
-        #gmat.setLGMap(c_LG_map, d_LG_map)
-    else:
-        # Set PETSc sequential matrix type
-        gmat.setType("seqaij")
-
-    gmat.setFromOptions()
-    gmat.setUp()
-
-    print('gmat.getSizes()=', gmat.getSizes())
-
-    mat_coo = mat.tosparse()
-    rows_coo, cols_coo, data_coo = mat_coo.row, mat_coo.col, mat_coo.data
-
-    mat_csr = mat_coo.tocsr()
-    mat_csr.eliminate_zeros()
-    data, indices, indptr = mat_csr.data, mat_csr.indices, mat_csr.indptr
-    #indptr_chunk = indptr[indptr >= dcart.starts[0] and indptr <= dcart.ends[0]]
-    #indices_chunk = indices[indices >= dcart.starts[1] and indices <= dcart.ends[1]]
-
-    mat_coo_local = mat.tocoo_local()
-    rows_coo_local, cols_coo_local, data_coo_local = mat_coo_local.row, mat_coo_local.col, mat_coo_local.data
-
-    local_petsc_index = psydac_to_petsc_local(mat.domain, [], [2,0])
-    global_petsc_index = get_petsc_local_to_global_shift(mat.domain)
-
-
-    print('dcart.global_starts=', dcart.global_starts)
-    print('dcart.global_ends=', dcart.global_ends)
-    
-    '''for k in range(comm.Get_size()):
-        if comm.Get_rank() == k:
-            local_indptr = indptr[1 + dcart.global_starts[0][comm.Get_rank()]:2+dcart.global_ends[0][comm.Get_rank()]]
-            local_indptr = [row_pter - dcart.global_starts[0][comm.Get_rank()] for row_pter in local_indptr]
-            local_indptr = [0, *local_indptr]
-        comm.Barrier()'''
-    
-    '''if comm.Get_rank() == 0:
-        local_indptr = [3,6]
-    else:
-        local_indptr = [3]'''
-    #local_indptr = indptr[1+ dcart.global_starts[comm.Get_rank()][0]:dcart.global_ends[comm.Get_rank()][0]+2]
-    #local_indptr = [0, *local_indptr]
-
-    if not comm:
-        print('178:indptr = ', indptr)
-        print('178:indices = ', indices)
-        print('178:data = ', data)
-    else:
-        for k in range(comm.Get_size()):
-            if comm.Get_rank() == k:
-                print('\nRank ', k)
-                print('mat=\n', mat_csr.toarray())
-                print('CSR: indptr = ', indptr)
-                #print('local_indptr = ', local_indptr)
-                print('CSR: indices = ', indices)
-                print('CSR: data = ', data)  
-
-
-                '''print('data_coo_local=', data_coo_local)
-                print('rows_coo_local=', rows_coo_local)
-                print('cols_coo_local=', cols_coo_local)
-
-                print('data_coo=', data_coo)
-                print('rows_coo=', rows_coo)
-                print('cols_coo=', cols_coo)'''
-
-            comm.Barrier()      
-
-    '''rows, cols, data = mat_coo.row, mat_coo.col, mat_coo.data
-    for k in range(comm.Get_size()):
-        if k == comm.Get_rank():
-            print('\nRank ', k, ': data.size =', data.size)
-            print('rows=', rows)
-            print('cols=', cols)
-            print('data=', data)
-        comm.Barrier()'''
-    
-
-    import time
-    t_prev = time.time() 
-    '''for k in range(len(rows_coo)):
-        gmat.setValues(rows_coo[k] - dcart.global_starts[0][comm.Get_rank()], cols_coo[k], data_coo[k])
-    '''
-    #gmat.setValuesCSR([r - dcart.global_starts[0][comm.Get_rank()] for r in indptr[1:]], indices, data)
-    #gmat.setValuesLocalCSR(local_indptr, indices, data)#, addv=PETSc.InsertMode.ADD_VALUES)
-    
-    r = gmat.Stencil(0,0,0)
-    c = gmat.Stencil(0,0,0)
-    s = np.prod([p*m for p, m in zip(mat.domain.pads, mat.domain.shifts)])
-    print('r=', r)
-    for k in range(comm.Get_size()):
-        if comm.Get_rank() == k:
-            print('\nrank ', k)
-            print('mat._data=', mat._data)
-            
-            print('mat.domain.pads=', mat.domain.pads)
-            print('mat.domain.shifts=', mat.domain.shifts)
-            print('mat._data (without ghost)=', mat._data[s:-s])
-
-        comm.Barrier()
-
-    gmat.setValuesStencil(mat._data[s:-s])
-
-
-    print('Rank ', comm.Get_rank() if comm else '-', ': duration of setValuesCSR :', time.time()-t_prev)
-    
-    '''if comm:
-        # Preallocate number of nonzeros per row
-        #row_lengths = np.count_nonzero(rows[None,:] == np.unique(rows)[:,None], axis=1).max()
-        
-        ##very slow:
-        #row_lengths = 0
-        #for r in np.unique(rows):
-        #    row_lengths = max(row_lengths, np.nonzero(rows==r)[0].size)
-        
-        row_lengths = np.unique(rows, return_counts=True)[1].max()
-
-        # NNZ is the number of non-zeros per row for the local portion of the matrix
-        t_prev = time.time() 
-        NNZ = comm.allreduce(row_lengths, op=MPI.MAX)
-        print('Rank ', comm.Get_rank() , ': duration of comm.allreduce :', time.time()-t_prev)
-
-        t_prev = time.time() 
-        gmat.setPreallocationNNZ(NNZ)
-        print('Rank ', comm.Get_rank() , ': duration of setPreallocationNNZ :', time.time()-t_prev)
-
-    t_prev = time.time() 
-    # Fill-in matrix values
-    for i in range(rows.size):
-        # The values have to be set in "addition mode", otherwise the default just takes the new value.
-        # This is here necessary, since the COO format can contain repeated entries.
-        gmat.setValues(rows[i], cols[i], data[i])#, addv=PETSc.InsertMode.ADD_VALUES)
-
-    print('Rank ', comm.Get_rank() , ': duration of setValues :', time.time()-t_prev)'''
-  
-    # Process inserted matrix entries
-    ################################################
-    # Note 12.03.2024:
-    # In the assembly PETSc uses global communication to distribute the matrix in a different way than Psydac.
-    # For this reason, at the moment we cannot compare directly each distributed 'chunck' of the Psydac and the PETSc matrices.
-    # In the future we would like that PETSc uses the partition from Psydac, 
-    # which might involve passing a DM Object.
-    ################################################
-    t_prev = time.time() 
-    gmat.assemble()
-    print('Rank ', comm.Get_rank() if comm else '-', ': duration of Mat assembly :', time.time()-t_prev)
-
     return gmat

--- a/psydac/linalg/utilities.py
+++ b/psydac/linalg/utilities.py
@@ -6,7 +6,7 @@ from math import sqrt
 from psydac.linalg.basic   import Vector
 from psydac.linalg.stencil import StencilVectorSpace, StencilVector
 from psydac.linalg.block   import BlockVector, BlockVectorSpace
-from psydac.linalg.topetsc import psydac_to_petsc_local, get_petsc_local_to_global_shift, petsc_to_psydac_local, global_to_psydac, get_npts_per_block
+from psydac.linalg.topetsc import petsc_local_to_psydac, get_npts_per_block
 
 __all__ = (
     'array_to_psydac',
@@ -75,9 +75,9 @@ def _array_to_psydac_recursive(x, u):
     
 #==============================================================================
 def petsc_to_psydac(x, Xh):
-    """Convert a PETSc.Vec object to a StencilVector or BlockVector. It assumes that PETSc was installed with the configuration for complex numbers.
-        We gather the petsc global vector in all the processes and extract the chunk owned by the Psydac Vector.
-        .. warning: This function will not work if the global vector does not fit in the process memory.
+    """
+    Convert a PETSc.Vec object to a StencilVector or BlockVector. It assumes that PETSc was installed with the configuration for complex numbers.
+    Uses the index conversion functions in psydac.linalg.topetsc.py.
 
     Parameters
     ----------
@@ -87,119 +87,34 @@ def petsc_to_psydac(x, Xh):
     Returns
     -------
     u : psydac.linalg.stencil.StencilVector | psydac.linalg.block.BlockVector
-        Psydac vector
+        Psydac vector. In the case of a BlockVector, the blocks must be StencilVector. The general case is not yet implemented.
     """
     
     if isinstance(Xh, BlockVectorSpace):
         if any([isinstance(Xh.spaces[b], BlockVectorSpace) for b in range(len(Xh.spaces))]):
             raise NotImplementedError('Block of blocks not implemented.')
+        
         u = BlockVector(Xh)
-
-        comm       = x.comm#u[0][0].space.cart.global_comm
-        dtype      = Xh._dtype#u[0][0].space.dtype
-        n_blocks   = Xh.n_blocks
-        #sendcounts = np.array(comm.allgather(len(x.array))) if comm else np.array([len(x.array)])
-        #recvbuf    = np.empty(sum(sendcounts), dtype='complex') # PETSc installed with complex configuration only handles complex vectors
+        comm       = x.comm
+        dtype      = Xh._dtype
         localsize, globalsize = x.getSizes()
-        #assert globalsize == u.shape[0], 'Sizes of global vectors do not match'
+        assert globalsize == u.shape[0], 'Sizes of global vectors do not match'
 
-
-        # Find shifts for process k:
+        # Find shift for process k:
+        # ..get number of points for each block, each process and each dimension:
         npts_local_per_block_per_process = np.array(get_npts_per_block(Xh)) #indexed [b,k,d] for block b and process k and dimension d
+        # ..get local sizes for each block and each process:
         local_sizes_per_block_per_process = np.prod(npts_local_per_block_per_process, axis=-1) #indexed [b,k] for block b and process k
+        # ..sum the sizes over all the blocks and the previous processes:
+        index_shift = 0 + np.sum(local_sizes_per_block_per_process[:,:comm.Get_rank()], dtype=int) #global variable
 
-        index_shift = 0 + np.sum(local_sizes_per_block_per_process[:,:comm.Get_rank()]) #+ np.sum(local_sizes_per_block_per_process[:b,comm.Get_rank()]) for b in range(n_blocks)]
-
-        #index_shift_per_block =  [0 + np.sum(local_sizes_per_block_per_process[b][0:x.comm.Get_rank()], dtype=int) for b in range(n_blocks)] #Global variable
-
-        print(f'rk={comm.Get_rank()}, local_sizes_per_block_per_process={local_sizes_per_block_per_process}, index_shift={index_shift}, u[0]._data={u[0]._data.shape}, u[1]._data={u[1]._data.shape}')
-
-
-        local_petsc_indices = np.arange(localsize)
-        global_petsc_indices = []
-        psydac_indices = []
-        block_indices = []
-        for petsc_index in local_petsc_indices:
-
-            block_index, psydac_index = global_to_psydac(Xh, petsc_index)#, comm=x.comm)            
-            psydac_indices.append(psydac_index)
-            block_indices.append(block_index)
-
-
-            global_petsc_indices.append(petsc_index + index_shift)
-
-            print(f'rank={comm.Get_rank()}, psydac_index = {psydac_index}, local_petsc_index={petsc_index}, petsc_global_index={global_petsc_indices[-1]}')
-
-        
-        for block_index, psydac_index, petsc_index in zip(block_indices, psydac_indices, global_petsc_indices):
-            value = x.getValue(petsc_index) # Global index
+        for local_petsc_index in range(localsize):
+            block_index, psydac_index = petsc_local_to_psydac(Xh, local_petsc_index)
+            # Get value of local PETSc vector passing the global PETSc index
+            value = x.getValue(local_petsc_index + index_shift) 
             if value != 0:
-                u[block_index[0]]._data[psydac_index] = value if dtype is complex else value.real
+                u[block_index[0]]._data[psydac_index] = value if dtype is complex else value.real # PETSc always handles dtype specified in the installation configuration
         
-
-
-
-        '''if comm:
-            # Gather the global array in all the processors
-            ################################################
-            # Note 12.03.2024:
-            # This global communication is at the moment necessary since PETSc distributes matrices and vectors different than Psydac. 
-            # In order to avoid it, we would need that PETSc uses the partition from Psydac, 
-            # which might involve passing a DM Object.
-            ################################################
-            comm.Allgatherv(sendbuf=x.array, recvbuf=(recvbuf, sendcounts))
-        else:
-            recvbuf[:] = x.array
-
-        inds = 0
-        for d in range(len(Xh.spaces)):
-            starts = [np.array(V.starts) for V in Xh.spaces[d].spaces]
-            ends   = [np.array(V.ends)   for V in Xh.spaces[d].spaces]
-
-            for i in range(len(starts)):
-                idx = tuple( slice(m*p,-m*p) for m,p in zip(u.space.spaces[d].spaces[i].pads, u.space.spaces[d].spaces[i].shifts) )
-                shape = tuple(ends[i]-starts[i]+1)
-                npts  = Xh.spaces[d].spaces[i].npts
-                # compute the global indices of the coefficents owned by the process using starts and ends
-                indices = np.array([np.ravel_multi_index( [s+x for s,x in zip(starts[i], xx)], dims=npts,  order='C' ) for xx in np.ndindex(*shape)] )
-                vals = recvbuf[indices+inds]
-
-                # With PETSc installation configuration for complex, all the numbers are by default complex. 
-                # In the float case, the imaginary part must be truncated to avoid warnings.
-                u[d][i]._data[idx] = (vals if dtype is complex else vals.real).reshape(shape)
-
-                inds += np.prod(npts)
-
-        else:
-        comm       = u[0].space.cart.global_comm
-        dtype      = u[0].space.dtype
-        sendcounts = np.array(comm.allgather(len(x.array))) if comm else np.array([len(x.array)])
-        recvbuf    = np.empty(sum(sendcounts), dtype='complex') # PETSc installed with complex configuration only handles complex vectors
-
-        if comm:
-            # Gather the global array in all the procs
-            # TODO: Avoid this global communication with a DM Object (see note above).
-            comm.Allgatherv(sendbuf=x.array, recvbuf=(recvbuf, sendcounts))
-        else:
-            recvbuf[:] = x.array
-
-        inds = 0
-        starts = [np.array(V.starts) for V in Xh.spaces]
-        ends   = [np.array(V.ends)   for V in Xh.spaces]
-        for i in range(len(starts)):
-            idx = tuple( slice(m*p,-m*p) for m,p in zip(u.space.spaces[i].pads, u.space.spaces[i].shifts) )
-            shape = tuple(ends[i]-starts[i]+1)
-            npts  = Xh.spaces[i].npts
-            # compute the global indices of the coefficents owned by the process using starts and ends
-            indices = np.array([np.ravel_multi_index( [s+x for s,x in zip(starts[i], xx)], dims=npts,  order='C' ) for xx in np.ndindex(*shape)] )
-            vals = recvbuf[indices+inds]
-
-            # With PETSc installation configuration for complex, all the numbers are by default complex. 
-            # In the float case, the imaginary part must be truncated to avoid warnings.
-            u[i]._data[idx] = (vals if dtype is complex else vals.real).reshape(shape)
-
-            inds += np.prod(npts)'''
-
     elif isinstance(Xh, StencilVectorSpace):
 
         u          = StencilVector(Xh)
@@ -208,90 +123,25 @@ def petsc_to_psydac(x, Xh):
         localsize, globalsize = x.getSizes()
         assert globalsize == u.shape[0], 'Sizes of global vectors do not match'
 
-        '''index_shift = get_petsc_local_to_global_shift(Xh)
-        petsc_local_indices = np.arange(localsize) 
-        petsc_indices = petsc_local_indices #+ index_shift
-        psydac_indices = [petsc_to_psydac_local(Xh, petsc_index) for petsc_index in petsc_indices]'''
+        # Find shift for process k:
+        # ..get number of points for each process and each dimension:
+        npts_local_per_block_per_process = np.array(get_npts_per_block(Xh))[0] #indexed [k,d] for process k and dimension d
+        # ..get local sizes for each process:
+        local_sizes_per_block_per_process = np.prod(npts_local_per_block_per_process, axis=-1) #indexed [k] for process k
+        # ..sum the sizes over all the previous processes:
+        index_shift = 0 + np.sum(local_sizes_per_block_per_process[:comm.Get_rank()], dtype=int) #global variable
 
-
-        # Find shifts for process k:
-        npts_local_per_block_per_process = np.array(get_npts_per_block(Xh)) #indexed [b,k,d] for block b and process k and dimension d
-        local_sizes_per_block_per_process = np.prod(npts_local_per_block_per_process, axis=-1) #indexed [b,k] for block b and process k
-
-        index_shift = 0 + np.sum(local_sizes_per_block_per_process[0][0:x.comm.Get_rank()], dtype=int) #Global variable
-
-
-        
-        local_petsc_indices = np.arange(localsize)
-        global_petsc_indices = []
-        psydac_indices = []
-        block_indices = []
-        for petsc_index in local_petsc_indices:
-
-            block_index, psydac_index = global_to_psydac(Xh, petsc_index)#, comm=x.comm)            
-            psydac_indices.append(psydac_index)
-            block_indices.append(block_index)
-            global_petsc_indices.append(petsc_index + index_shift)
-
-
-
-
-        #psydac_indices = [global_to_psydac(Xh, petsc_index, comm=x.comm) for petsc_index in petsc_indices]
-
-
-        '''if comm is not None:
-            for k in range(comm.Get_size()):
-                if k == comm.Get_rank():
-                    print('\nRank ', k)
-                    print('petsc_indices=\n', petsc_indices)
-                    print('psydac_indices=\n', psydac_indices)
-                    print('index_shift=', index_shift)
-                comm.Barrier()'''
-
-        for block_index, psydac_index, petsc_index in zip(block_indices, psydac_indices, global_petsc_indices):
-            value = x.getValue(petsc_index) # Global index
+        for local_petsc_index in range(localsize):
+            block_index, psydac_index = petsc_local_to_psydac(Xh, local_petsc_index) 
+            # Get value of local PETSc vector passing the global PETSc index
+            value = x.getValue(local_petsc_index + index_shift)
             if value != 0:
-                u._data[psydac_index] = value if dtype is complex else value.real
-        
-        '''sendcounts = np.array(comm.allgather(len(x.array))) if comm else np.array([len(x.array)])
-        recvbuf    = np.empty(sum(sendcounts), dtype='complex') # PETSc installed with complex configuration only handles complex vectors 
-
-        if comm:
-            # Gather the global array in all the procs
-            # TODO: Avoid this global communication with a DM Object (see note above).
-            comm.Allgatherv(sendbuf=x.array, recvbuf=(recvbuf, sendcounts))
-        else:
-            recvbuf[:] = x.array
-
-        # compute the global indices of the coefficents owned by the process using starts and ends
-        starts = np.array(Xh.starts)
-        ends   = np.array(Xh.ends)
-        shape  = tuple(ends-starts+1)
-        npts   = Xh.npts
-        indices = np.array([np.ravel_multi_index( [s+x for s,x in zip(starts, xx)], dims=npts,  order='C' ) for xx in np.ndindex(*shape)] )
-        idx = tuple( slice(m*p,-m*p) for m,p in zip(u.space.pads, u.space.shifts) )
-        vals = recvbuf[indices]
-
-        # With PETSc installation configuration for complex, all the numbers are by default complex. 
-        # In the float case, the imaginary part must be truncated to avoid warnings.
-        u._data[idx] = (vals if dtype is complex else vals.real).reshape(shape)'''
+                u._data[psydac_index] = value if dtype is complex else value.real # PETSc always handles dtype specified in the installation configuration            
 
     else:
         raise ValueError('Xh must be a StencilVectorSpace or a BlockVectorSpace')
 
     u.update_ghost_regions()
-
-    '''if comm is not None:
-        u_arr = u.toarray()
-        x_arr = x.array.real
-        for k in range(comm.Get_size()):
-            if k == comm.Get_rank():
-                print('\nRank ', k)
-                print('u.toarray()=\n', u_arr)
-                #print('x.array=\n', x_arr)
-                #print('u._data=\n', u._data)
-
-            comm.Barrier()'''
 
     return u
 

--- a/psydac/linalg/utilities.py
+++ b/psydac/linalg/utilities.py
@@ -118,8 +118,8 @@ def petsc_to_psydac(x, Xh):
     elif isinstance(Xh, StencilVectorSpace):
 
         u          = StencilVector(Xh)
-        comm       = u.space.cart.global_comm
-        dtype      = u.space.dtype
+        comm       = x.comm
+        dtype      = Xh.dtype
         localsize, globalsize = x.getSizes()
         assert globalsize == u.shape[0], 'Sizes of global vectors do not match'
 

--- a/psydac/linalg/utilities.py
+++ b/psydac/linalg/utilities.py
@@ -91,6 +91,8 @@ def petsc_to_psydac(x, Xh):
     """
     
     if isinstance(Xh, BlockVectorSpace):
+        if any([isinstance(Xh.spaces[b], BlockVectorSpace) for b in range(len(Xh.spaces))]):
+            raise NotImplementedError('Block of blocks not implemented.')
         u = BlockVector(Xh)
 
         comm       = x.comm#u[0][0].space.cart.global_comm


### PR DESCRIPTION
Implement a new conversion to PETSc that reduces the communication in the assembly to almost none. The converted `PETSc.Vec` and `PETSc.Mat` objects locally contain the same coefficients as the local `StencilVector` or `StencilMatrix`/`BlockLinearOperator`. This is done with an index conversion function that maps the Psydac natural multi-index to the PETSc global index.

done: added kernel for computing I,J,V format

The conversion is not implemented for:
- BlockVector with at least a block that is not a StencilVector.
- BlockLinearOperator with at least a block that is not a StencilMatrix.
- Matrix-free `LinearOperator`s. 