### PR TITLE
call exposed domain and codomain in linalg/basic.py

### DIFF
--- a/psydac/linalg/basic.py
+++ b/psydac/linalg/basic.py
@@ -279,7 +279,7 @@ class LinearOperator(ABC):
         a new object of the class ScaledLinearOperator.
         
         """
-        return ScaledLinearOperator(self._domain, self._codomain, -1.0, self)
+        return ScaledLinearOperator(self.domain, self.codomain, -1.0, self)
 
     def __mul__(self, c):
         """


### PR DESCRIPTION
the `__neg__` function in class `LinearOperator` uses the `_domain` and `_codomain` attributes, which is wrong since these may not be defined. It should use the exposed (interface) attributes `domain` and `codomain`