### PR TITLE
Fixes for CI failures caused by new macOS runner version and numpy 2.0

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -36,12 +36,14 @@ jobs:
         make -C docs clean
         make -C docs html
         python docs/update_links.py
-    - name: Setup Pages
-      uses: actions/configure-pages@v3
-    - name: Upload artifact
-      uses: actions/upload-pages-artifact@v1
-      with:
-        path: 'docs/build/html'
+
+    # Disable docs deployment for now as we're in psydac fork repo
+    # - name: Setup Pages
+    #   uses: actions/configure-pages@v3
+    # - name: Upload artifact
+    #   uses: actions/upload-pages-artifact@v1
+    #   with:
+    #     path: 'docs/build/html'
 
   deploy_docs:
     if: github.event_name != 'pull_request'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,10 @@ dependencies = [
     'tblib',
 
     # IGAKIT - not on PyPI
-    'igakit @ https://github.com/dalcinl/igakit/archive/refs/heads/master.zip'
+
+    # !! WARNING !! Path to igakit below is from fork pyccel/igakit. This was done to
+    # quickly fix the numpy 2.0 issue. See https://github.com/dalcinl/igakit/pull/4
+    'igakit @ https://github.com/pyccel/igakit/archive/refs/heads/bugfix-numpy2.0.zip'
 ]
 
 [project.urls]


### PR DESCRIPTION
Workaround to fix CI issues. Based from PR https://github.com/pyccel/psydac/pull/411