### PR TITLE
[test-only: do not merge] Test sympde branch terminal_expressions_for_NS

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -141,9 +141,9 @@ jobs:
       - name: Download a development version of sympde
         working-directory: /tmp
         run: |
-          wget https://github.com/pyccel/sympde/archive/refs/heads/master.zip
-          unzip ./master.zip
-          python3 -m pip install ./sympde-master          
+          wget https://github.com/pyccel/sympde/archive/refs/heads/terminal_expressions_for_NS.zip
+          unzip ./terminal_expressions_for_NS.zip
+          python3 -m pip install ./sympde-terminal_expressions_for_NS          
 
       - name: Install project
         run: |


### PR DESCRIPTION
The purpose of this PR is not to be merged, but to trigger the psydac test suite against a specific sympde branch.

In particular, there is nothing to review or approve. If the tests fail for this PR, then:
- either this is due to an error in sympde and the fix should be done in the corresponding sympde branch
- or this is due to a problem in psydac which should be handled in a dedicated PR (not this one).

Here we are verifying that psydac will not be broken by changes in the sympde
PR https://github.com/pyccel/sympde/pull/161 are breaking psydac.