### PR TITLE
Newest version of mpi4py is incompatible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 wheel
 setuptools >= 61, != 67.2.0
-numpy  >= 1.16
+numpy  >= 1.16, < 2.0.0
 scipy  >= 1.14
 Cython >= 0.25, < 3.0
-mpi4py >= 3.0.0
+mpi4py >= 3.0.0, < 4.0.0
 
 # Required to build h5py from source
 pkgconfig

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 wheel
 setuptools >= 61, != 67.2.0
-numpy  >= 1.16, < 2.0.0
+numpy  >= 1.16
 scipy  >= 1.14
 Cython >= 0.25, < 3.0
-mpi4py >= 3.0.0, < 4.0.0
+mpi4py >= 3.0.0, < 4
 
 # Required to build h5py from source
 pkgconfig


### PR DESCRIPTION
As it can be seen in PR #19 , the tests do not run with the latest version of mpi4py . This PR just ensures that during the installation a previous version is installed instead.

- Version 4.0.0 of mpi4py is incompatible because of the change listed in https://mpi4py.readthedocs.io/en/stable/changes.html:

 > Group.Translate_ranks() is no longer a class method but an instance method. Existing codes using the former class method are expected to continue working.
 
 This function is used in https://github.com/campospinto/psydac_dev/blame/2ed9431fd8a3bbcf46584756a4d7ffd290c2d36b/psydac/ddm/cart.py#L268C13-L268C141 . Now it only accepts two arguments: https://docs.open-mpi.org/en/v5.0.x/man-openmpi/man3/MPI_Group_translate_ranks.3.html


